### PR TITLE
[Feat/#5] 카카오 및 애플로그인 구현

### DIFF
--- a/FLOV.xcodeproj/project.pbxproj
+++ b/FLOV.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		792CF8942DCFB6BE0074FB34 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 792CF8932DCFB6BE0074FB34 /* .gitignore */; };
 		792CF8962DCFB7FE0074FB34 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 792CF8952DCFB7FE0074FB34 /* Config.xcconfig */; };
 		792CFA432DD094150074FB34 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 792CFA422DD094150074FB34 /* Alamofire */; };
+		79ED5CD32DD1EE8E006D3033 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 79ED5CD22DD1EE8E006D3033 /* KakaoSDKAuth */; };
+		79ED5CD52DD1EE8E006D3033 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 79ED5CD42DD1EE8E006D3033 /* KakaoSDKCommon */; };
+		79ED5CD72DD1EE8E006D3033 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 79ED5CD62DD1EE8E006D3033 /* KakaoSDKUser */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,7 +47,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79ED5CD72DD1EE8E006D3033 /* KakaoSDKUser in Frameworks */,
 				792CFA432DD094150074FB34 /* Alamofire in Frameworks */,
+				79ED5CD52DD1EE8E006D3033 /* KakaoSDKCommon in Frameworks */,
+				79ED5CD32DD1EE8E006D3033 /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,6 +96,9 @@
 			name = FLOV;
 			packageProductDependencies = (
 				792CFA422DD094150074FB34 /* Alamofire */,
+				79ED5CD22DD1EE8E006D3033 /* KakaoSDKAuth */,
+				79ED5CD42DD1EE8E006D3033 /* KakaoSDKCommon */,
+				79ED5CD62DD1EE8E006D3033 /* KakaoSDKUser */,
 			);
 			productName = FLOV;
 			productReference = 792CF87E2DCFB3880074FB34 /* FLOV.app */;
@@ -121,6 +130,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				792CFA412DD094150074FB34 /* XCRemoteSwiftPackageReference "Alamofire" */,
+				79ED5CD12DD1EE8E006D3033 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 792CF87F2DCFB3880074FB34 /* Products */;
@@ -280,6 +290,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = FLOV/FLOV.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FLOV/Preview Content\"";
@@ -317,6 +328,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = FLOV/FLOV.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FLOV/Preview Content\"";
@@ -381,6 +393,14 @@
 				minimumVersion = 5.10.2;
 			};
 		};
+		79ED5CD12DD1EE8E006D3033 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.24.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -388,6 +408,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 792CFA412DD094150074FB34 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
+		};
+		79ED5CD22DD1EE8E006D3033 /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 79ED5CD12DD1EE8E006D3033 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		79ED5CD42DD1EE8E006D3033 /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 79ED5CD12DD1EE8E006D3033 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
+		79ED5CD62DD1EE8E006D3033 /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 79ED5CD12DD1EE8E006D3033 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/FLOV.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FLOV.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "11b78eba97192d19796cff581fdf69b3e65b441188b1448a1b67e5d7b825a354",
+  "originHash" : "fcdb6d5dc76fef3126c97e3f42a1ae0bb40cd2c958e8591ac4547ce131a2698e",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
         "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "787763e335949dfad6b721aa04771e22d04e1493",
+        "version" : "2.24.2"
       }
     }
   ],

--- a/FLOV/App/FLOVApp.swift
+++ b/FLOV/App/FLOVApp.swift
@@ -6,12 +6,24 @@
 //
 
 import SwiftUI
+import KakaoSDKAuth
+import KakaoSDKCommon
 
 @main
 struct FLOVApp: App {
+    init() {
+        /// KakaoSDK 초기화
+        KakaoSDK.initSDK(appKey: Config.kakaoNativeAppKey)
+    }
+    
     var body: some Scene {
         WindowGroup {
             SignInView()
+                .onOpenURL { url in
+                    if AuthApi.isKakaoTalkLoginUrl(url) {
+                        _ = AuthController.handleOpenUrl(url: url)
+                    }
+                }
         }
     }
 }

--- a/FLOV/FLOV.entitlements
+++ b/FLOV/FLOV.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/FLOV/Info.plist
+++ b/FLOV/Info.plist
@@ -2,6 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
close #5 

## *⛳️ Work Description*
- 카카오 및 애플로그인 구현을 완료했습니다
- 뷰모델로 로직을 분리해야합니다.

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|카카오톡으로 회원가입|<img width="250" alt="AppFlow" src="https://github.com/user-attachments/assets/e08ec105-790e-4258-b404-8b5560672b23">|
|카카오계정으로 회원가입/로그인|<img width="250" alt="AppFlow" src="https://github.com/user-attachments/assets/ca4745b8-3617-47f1-8f45-6ae58b42ae42">|
|애플 회원가입|<img width="250" alt="AppFlow" src="https://github.com/user-attachments/assets/4e3bc493-9297-4347-82dc-044d1b6dc55e">|
|애플 로그인|<img width="250" alt="AppFlow" src="https://github.com/user-attachments/assets/87cd2d0e-4d9e-49f6-9872-1a6d4fc1597a">|


## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
