### PR TITLE
[Feat] 로그인 상태관리

### DIFF
--- a/FLOV/Core/DIContainer/DIContainer.swift
+++ b/FLOV/Core/DIContainer/DIContainer.swift
@@ -11,7 +11,9 @@ final class DIContainer {
     let services: Services
     
     struct Services {
+        let networkManager: NetworkManagerType
         let userRepository: UserRepositoryType
+        let authRepository: AuthRepositoryType
     }
     
     init(

--- a/FLOV/Core/DIContainer/DIContainerModifier.swift
+++ b/FLOV/Core/DIContainer/DIContainerModifier.swift
@@ -8,9 +8,21 @@
 import SwiftUI
 
 struct DIContainerModifier: ViewModifier {
-    private let container = DIContainer(
-        services: .init(userRepository: UserRepository.shared)
-    )
+    private let container: DIContainer
+    
+    init() {
+        let networkManager = NetworkManager(tokenManager: TokenManager.shared)
+        let authRepository = AuthRepository(networkManager: networkManager, tokenManager: TokenManager.shared)
+        let userRepository = UserRepository(networkManager: networkManager, tokenManager: TokenManager.shared)
+        
+        self.container = DIContainer(
+            services: .init(
+                networkManager: networkManager,
+                userRepository: userRepository,
+                authRepository: authRepository
+            )
+        )
+    }
     
     func body(content: Content) -> some View {
         content

--- a/FLOV/Core/Network/NetworkError.swift
+++ b/FLOV/Core/Network/NetworkError.swift
@@ -13,6 +13,7 @@ enum NetworkError: Error {
     case statusCode(Int) // HTTP 4xx/5xx
     case decoding(Error) // JSON 디코딩 실패
     case apiError(String) // 서버가 내려주는 message
+    case refreshTokenExpired // 리프레시토큰 만료
     case corsError // CORS 등 특수 처리
 }
 
@@ -31,6 +32,8 @@ extension NetworkError: LocalizedError {
             return message
         case .corsError:
             return "CORS 오류가 발생했습니다."
+        case .refreshTokenExpired:
+            return "토큰이 만료되었습니다. 다시 로그인해주세요."
         }
     }
 }

--- a/FLOV/Core/Network/NetworkLog.swift
+++ b/FLOV/Core/Network/NetworkLog.swift
@@ -1,0 +1,53 @@
+//
+//  NetworkLog.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/18/25.
+//
+
+import Foundation
+
+#if DEBUG
+enum NetworkLog {
+    
+    private static let isPrint = true
+    
+    /// 네트워크 성공시 출력합니다.
+    static func success<T: Decodable>(
+        url: String,
+        statusCode: Int,
+        data: T
+    ) {
+        let message = """
+            [✅ SUCCESS]
+            - endPoint: \(url)
+            - statusCode: \(statusCode)
+            =====================================================
+            """
+        
+        if isPrint {
+            print(message)
+            dump(data)
+        }
+    }
+    
+    /// 네트워크 로그를 출력합니다.
+    static func failure<T: Decodable> (
+        url: String,
+        statusCode: Int,
+        data: T
+    ) {
+        let message = """
+            [❌ FAILURE]
+            - endPoint: \(url)
+            - statusCode: \(statusCode)
+            =====================================================
+            """
+        
+        if isPrint {
+            print(message)
+            dump(data)
+        }
+    }
+}
+#endif

--- a/FLOV/Core/Network/NetworkManager.swift
+++ b/FLOV/Core/Network/NetworkManager.swift
@@ -15,8 +15,11 @@ protocol NetworkManagerType {
 }
 
 final class NetworkManager: NetworkManagerType {
-    static let shared: NetworkManagerType = NetworkManager()
-    private init() { }
+    private let tokenManager: TokenManager
+    
+    init(tokenManager: TokenManager) {
+        self.tokenManager = tokenManager
+    }
     
     func callRequest<T: Decodable, U: Router>(_ api: U) async throws -> T {
         // 서버 응답(Data + HTTPURLResponse)
@@ -108,11 +111,11 @@ extension NetworkManager {
             // refresh
             
             do {
-                let tokens = try await AuthRepository.shared.refresh()
+                let refreshResponse: RefreshResponse = try await callRequest(AuthAPI.refresh)
                 
-                TokenManager.shared.updateAuthTokens(
-                    access: tokens.accessToken,
-                    refresh: tokens.refreshToken
+                tokenManager.updateAuthTokens(
+                    access: refreshResponse.accessToken,
+                    refresh: refreshResponse.refreshToken
                 )
                 // retry
                 return try await self.callRequest(api)

--- a/FLOV/Core/Network/NetworkManager.swift
+++ b/FLOV/Core/Network/NetworkManager.swift
@@ -32,12 +32,23 @@ final class NetworkManager: NetworkManagerType {
         // 상태코드 분기처리
         if (200..<300).contains(status) {
             do {
-                return try JSONDecoder().decode(T.self, from: data)
+                let decoded: T = try JSONDecoder().decode(T.self, from: data)
+                NetworkLog.success(
+                    url: api.path,
+                    statusCode: status,
+                    data: decoded
+                )
+                return decoded
             } catch {
                 throw NetworkError.decoding(error)
             }
         } else {
             if let errModel = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
+                NetworkLog.failure(
+                    url: api.path,
+                    statusCode: status,
+                    data: errModel
+                )
                 throw NetworkError.apiError(errModel.message)
             } else {
                 throw NetworkError.statusCode(status)
@@ -63,13 +74,24 @@ final class NetworkManager: NetworkManagerType {
         // 상태코드 분기처리
         if (200..<300).contains(status) {
             do {
-                return try JSONDecoder().decode(T.self, from: data)
+                let decoded: T = try JSONDecoder().decode(T.self, from: data)
+                NetworkLog.success(
+                    url: api.path,
+                    statusCode: status,
+                    data: decoded
+                )
+                return decoded
             } catch {
                 throw NetworkError.decoding(error)
             }
         } else {
-            if let err = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
-                throw NetworkError.apiError(err.message)
+            if let errModel = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
+                NetworkLog.failure(
+                    url: api.path,
+                    statusCode: status,
+                    data: errModel
+                )
+                throw NetworkError.apiError(errModel.message)
             } else {
                 throw NetworkError.statusCode(status)
             }
@@ -82,15 +104,22 @@ extension NetworkManager {
     func callWithRefresh<T: Decodable>(_ api: Router, as type: T.Type) async throws -> T {
         do {
             return try await self.callRequest(api)
-        } catch NetworkError.statusCode(let code) where code == 419 {
+        } catch {
             // refresh
-            let tokens = try await AuthRepository.shared.refresh()
-            TokenManager.shared.updateAuthTokens(
-                access: tokens.accessToken,
-                refresh: tokens.refreshToken
-            )
-            // retry
-            return try await self.callRequest(api)
+            
+            do {
+                let tokens = try await AuthRepository.shared.refresh()
+                
+                TokenManager.shared.updateAuthTokens(
+                    access: tokens.accessToken,
+                    refresh: tokens.refreshToken
+                )
+                // retry
+                return try await self.callRequest(api)
+            } catch {
+                UserDefaultsManager.isSigned = false
+                throw NetworkError.refreshTokenExpired
+            }
         }
     }
 }

--- a/FLOV/Core/Network/Repository/AuthRepository.swift
+++ b/FLOV/Core/Network/Repository/AuthRepository.swift
@@ -12,11 +12,13 @@ protocol AuthRepositoryType {
 }
 
 final class AuthRepository: AuthRepositoryType {
-    static let shared: AuthRepositoryType = AuthRepository()
-    private let networkManager: NetworkManagerType = NetworkManager.shared
-    private let tokenManager = TokenManager.shared
+    private let networkManager: NetworkManagerType
+    private let tokenManager: TokenManager
     
-    private init() {}
+    init(networkManager: NetworkManagerType, tokenManager: TokenManager) {
+        self.networkManager = networkManager
+        self.tokenManager = tokenManager
+    }
     
     func refresh() async throws -> RefreshResponse {
         let response: RefreshResponse = try await networkManager.callRequest(AuthAPI.refresh)

--- a/FLOV/Core/Network/Repository/UserRepository.swift
+++ b/FLOV/Core/Network/Repository/UserRepository.swift
@@ -46,6 +46,8 @@ final class UserRepository: UserRepositoryType {
             refresh: response.refreshToken
         )
         
+        UserDefaultsManager.isSigned = true
+        
         return response
     }
     
@@ -57,6 +59,8 @@ final class UserRepository: UserRepositoryType {
             refresh: response.refreshToken
         )
         
+        UserDefaultsManager.isSigned = true
+        
         return response
     }
     
@@ -67,6 +71,8 @@ final class UserRepository: UserRepositoryType {
             access: response.accessToken,
             refresh: response.refreshToken
         )
+        
+        UserDefaultsManager.isSigned = true
         
         return response
     }

--- a/FLOV/Core/Network/Repository/UserRepository.swift
+++ b/FLOV/Core/Network/Repository/UserRepository.swift
@@ -17,11 +17,13 @@ protocol UserRepositoryType {
 }
 
 final class UserRepository: UserRepositoryType {
-    static let shared: UserRepositoryType = UserRepository()
-    private let networkManager: NetworkManagerType = NetworkManager.shared
-    private let tokenManager = TokenManager.shared
+    private let networkManager: NetworkManagerType
+    private let tokenManager: TokenManager
     
-    private init() {}
+    init(networkManager: NetworkManagerType, tokenManager: TokenManager) {
+        self.networkManager = networkManager
+        self.tokenManager = tokenManager
+    }
     
     func emailValidate(request: EmailValidateRequest) async throws -> EmailValidateResponse {
         try await networkManager.callRequest(UserAPI.emailValidate(request: request))

--- a/FLOV/Core/Path/PathModel/PathModelBuilder.swift
+++ b/FLOV/Core/Path/PathModel/PathModelBuilder.swift
@@ -24,6 +24,7 @@ extension PathModel {
         case .keep:
             KeepView()
         case .profile:
+//            let vm = ProfileViewModel(userRepository: container.services.userRepos)
             ProfileView()
         case .profileEdit:
             ProfileEditView()

--- a/FLOV/Core/Path/PathModel/PathModelBuilder.swift
+++ b/FLOV/Core/Path/PathModel/PathModelBuilder.swift
@@ -12,7 +12,7 @@ extension PathModel {
     func build(_ screen: Screen) -> some View {
         switch screen {
         case .activity:
-            ActivityView()
+            ActivityView(userRepo: container.services.userRepository)
         case .activityDetail:
             ActivityDetailView()
         case .post:

--- a/FLOV/Core/UserDefaults/UserDefaultsManager.swift
+++ b/FLOV/Core/UserDefaults/UserDefaultsManager.swift
@@ -1,0 +1,32 @@
+//
+//  UserDefaultsManager.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/17/25.
+//
+
+import Foundation
+
+@propertyWrapper
+struct FlovUserDefaults<T> {
+    let key: String
+    let defaultValue: T
+    
+    var wrappedValue: T {
+        get {
+            UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+}
+
+enum UserDefaultsManager {
+    enum Key: String {
+        case isSigned
+    }
+    
+    @FlovUserDefaults(key: Key.isSigned.rawValue, defaultValue: false)
+    static var isSigned
+}

--- a/FLOV/Feature/01_Register/View/EmailSignInView.swift
+++ b/FLOV/Feature/01_Register/View/EmailSignInView.swift
@@ -77,8 +77,9 @@ private extension EmailSignInView {
     }
 }
 
-#if DEBUG
-#Preview {
-    EmailSignInView(viewModel: EmailSignInViewModel(userRepository: UserRepository.shared))
-}
-#endif
+//#if DEBUG
+//#Preview {
+//    EmailSignInView(viewModel: EmailSignInViewModel(userRepository: UserRepository(networkManager: NetworkManager(tokenManager: TokenManager.shared), tokenManager: TokenManager.shared)))
+//        .injectDIContainer()
+//}
+//#endif

--- a/FLOV/Feature/01_Register/View/SignInView.swift
+++ b/FLOV/Feature/01_Register/View/SignInView.swift
@@ -93,12 +93,12 @@ private extension SignInView {
     }
 }
 
-#if DEBUG
-#Preview {
-    SignInView(
-        viewModel: SignInViewModel(
-            userRepository: UserRepository.shared
-        )
-    )
-}
-#endif
+//#if DEBUG
+//#Preview {
+//    SignInView(
+//        viewModel: SignInViewModel(
+//            userRepository: UserRepository.shared
+//        )
+//    )
+//}
+//#endif

--- a/FLOV/Feature/01_Register/View/SignUpView.swift
+++ b/FLOV/Feature/01_Register/View/SignUpView.swift
@@ -143,8 +143,8 @@ extension SignUpView {
 }
 
 
-#if DEBUG
-#Preview {
-    SignUpView(viewModel: SignUpViewModel(userRepository: UserRepository.shared))
-}
-#endif
+//#if DEBUG
+//#Preview {
+//    SignUpView(viewModel: SignUpViewModel(userRepository: UserRepository.shared))
+//}
+//#endif

--- a/FLOV/Feature/01_Register/ViewModel/SignInViewModel.swift
+++ b/FLOV/Feature/01_Register/ViewModel/SignInViewModel.swift
@@ -117,12 +117,9 @@ extension SignInViewModel {
             }
         }
         
-        let response = try await userRepository.kakaoLogin(
+        _ = try await userRepository.kakaoLogin(
             request: .init(oauthToken: oauth.accessToken, deviceToken: nil)
         )
-        
-        // TODO: NetworkLog라는 디버깅용 객체 만들어서 대응
-        dump(response)
     }
     
     private func appleLogin(result: Result<ASAuthorization, Error>) async throws {
@@ -140,10 +137,9 @@ extension SignInViewModel {
                 .compactMap { $0 }
                 .joined()
             
-            let response = try await userRepository.appleLogin(
+            _ = try await userRepository.appleLogin(
                 request: .init(idToken: idToken, deviceToken: nil, nick: name)
             )
-            print("애플 로그인 성공:", response)
             
         case .failure(let error):
             throw error

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -9,17 +9,34 @@ import SwiftUI
 
 struct ActivityView: View {
     @EnvironmentObject private var pathModel: PathModel
+    @State private var isSigned: Bool = false
+    
+    let userRepo = UserRepository.shared
     
     var body: some View {
         Button {
-            pathModel.presentFullScreenCover(.signIn)
+            if !UserDefaultsManager.isSigned {
+                pathModel.presentFullScreenCover(.signIn)
+            } else {
+                Task {
+                    do {
+                        _ = try await userRepo.profileLookup()
+                        isSigned = true                // 성공 시 true
+                    } catch {
+                        isSigned = false               // (refresh 실패 포함) 실패 시 false
+                        UserDefaultsManager.isSigned = false
+                        pathModel.presentFullScreenCover(.signIn) // 다시 로그인 화면으로
+                    }
+                }
+            }
         } label: {
             Text("ActivityView")
         }
+        .alert("로그인된 유저입니다.", isPresented: $isSigned) { }
     }
 }
 
-#Preview {
-    ActivityView()
-        .injectDIContainer()
-}
+//#Preview {
+//    ActivityView()
+//        .injectDIContainer()
+//}

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -11,7 +11,7 @@ struct ActivityView: View {
     @EnvironmentObject private var pathModel: PathModel
     @State private var isSigned: Bool = false
     
-    let userRepo = UserRepository.shared
+    let userRepo: UserRepositoryType
     
     var body: some View {
         Button {

--- a/FLOV/Feature/06_Profile/View/ProfileView.swift
+++ b/FLOV/Feature/06_Profile/View/ProfileView.swift
@@ -8,11 +8,39 @@
 import SwiftUI
 
 struct ProfileView: View {
+//    @StateObject var viewModel: ProfileViewModel
+    
     var body: some View {
-        Text("ProfileView")
+        ZStack {
+//            if viewModel.output.isLoading {
+//                ProgressView()
+//            }
+            
+            VStack {
+                Text("ProfileView")
+//                Button("프로필 조회") {
+//                    viewModel.action(.fetchProfile)
+//                }
+//                
+//                Text(viewModel.output.profile?.user_id ?? "아이디없음")
+//                Text(viewModel.output.profile?.email ?? "이메일없음")
+//                Text(viewModel.output.profile?.nick ?? "닉네임없음")
+            }
+        }
+//        .onAppear {
+//            viewModel.action(.fetchProfile)
+//        }
+//        .alert("로그인이 만료되었습니다.", isPresented: $viewModel.output.showSessionExpiredAlert) {
+//            Button("로그인") {
+//                viewModel.pathModel.presentFullScreenCover(.signIn)
+//            }
+//            Button("취소", role: .cancel) {}
+//        } message: {
+//            Text("다시 로그인해주세요.")
+//        }
     }
 }
 
-#Preview {
-    ProfileView()
-}
+//#Preview {
+//    ProfileView()
+//}

--- a/FLOV/Feature/06_Profile/ViewModel/ProfileViewModel.swift
+++ b/FLOV/Feature/06_Profile/ViewModel/ProfileViewModel.swift
@@ -1,0 +1,105 @@
+//
+//  ProfileViewModel.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/17/25.
+//
+
+import Foundation
+import Combine
+
+//final class ProfileViewModel: ViewModelType {
+//    private let userRepository: UserRepositoryType
+//    private let pathModel: PathModel
+//    private let userDefaultsManager: UserDefaultsManager
+//    var cancellables: Set<AnyCancellable>
+//    var input: Input
+//    @Published var output: Output
+//    
+//    init(
+//        userRepository: UserRepositoryType,
+//        pathModel: PathModel,
+//        userDefaultsManager: UserDefaultsManager,
+//        cancellables: Set<AnyCancellable> = Set<AnyCancellable>(),
+//        input: Input = Input(),
+//        output: Output = Output()
+//    ) {
+//        self.userRepository = userRepository
+//        self.pathModel = pathModel
+//        self.userDefaultsManager = userDefaultsManager
+//        self.cancellables = cancellables
+//        self.input = input
+//        self.output = output
+//        transform()
+//    }
+//    
+//    struct Input {
+//        let fetchTrigger = PassthroughSubject<Void, Never>()
+//    }
+//    
+//    struct Output {
+//        var isLoading = false
+//        var showSessionExpiredAlert = false
+//        var profile: ProfileLookupResponse?
+//        
+//        var showErrorAlert = false
+//        var errorMessage = ""
+//    }
+//}
+//
+//// MARK: - Action
+//extension ProfileViewModel {
+//    enum Action {
+//        case fetchProfile
+//    }
+//    
+//    func action(_ action: Action) {
+//        switch action {
+//        case .fetchProfile:
+//            input.fetchTrigger.send(())
+//        }
+//    }
+//}
+//
+//// MARK: - Transform
+//extension ProfileViewModel {
+//    func transform() {
+//        setUpFetchProfile()
+//    }
+//    
+//    private func setUpFetchProfile() {
+//        input.fetchTrigger
+//            .sink { [weak self] _ in
+//                guard let self = self else { return }
+//                
+//                Task {
+//                    await self.fetchProfile()
+//                }
+//            }
+//            .store(in: &cancellables)
+//    }
+//}
+//
+//// MARK: - Function
+//@MainActor
+//extension ProfileViewModel {
+//    private func fetchProfile() async {
+//        output.isLoading = true
+//        
+//        if !userDefaultsManager.isSigned {
+//            pathModel.presentFullScreenCover(.signIn)
+//            return
+//        }
+//        
+//        do {
+//            let profile = try await userRepository.profileLookup()
+//            output.profile = profile
+//        } catch NetworkError.refreshTokenExpired {
+//            output.showSessionExpiredAlert = true
+//        } catch {
+//            output.showErrorAlert = true
+//            output.errorMessage = error.localizedDescription
+//        }
+//        output.isLoading = false
+//    }
+//}


### PR DESCRIPTION
close #15 

## *⛳️ Work Description*
- UserDefaults로 로그인 상태관리를 하겠습니다.
- NetworkManager와 각 레포지토리를 DIContainer에서 주입하는 형식으로 변경했습니다.
- TokenManager와 KeychainManager는 싱글톤으로 놔둔 상태입니다.

- Intercepter를 도입하려고 했으나, actor와 NSLock 등 수정해야 할 코드가 많아져서 보류했습니다.
- UserDefaults를 통해 isSigned를 타입메서드로 관리하는게 신경쓰이지만, 추후에 불편함을 느끼면 수정하겠습니다.

- 로그인로직을 변경해야합니다.
- 회원가입, 로그인 로직을 제외하고 모든 API 요청에 accessToken이 필요해서 둘러보기 로직을 변경해야 합니다.


## *📸 Screenshot*



## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
