### PR TITLE
[Feat] ActivityView 네트워크 작업

### DIFF
--- a/FLOV.xcodeproj/xcshareddata/xcschemes/FLOV.xcscheme
+++ b/FLOV.xcodeproj/xcshareddata/xcschemes/FLOV.xcscheme
@@ -34,7 +34,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -34,17 +34,18 @@ struct ActivityCard: View {
                     
                     Spacer()
                     
+                    // TODO: 여기 로직 수정
                     // TODO: hot의 orderCount 디테일 통신으로 처리
                     // TODO: detail의 endDate를 통해 countdown 계산 후 특정 기준을 충족할 경우 .deadline을 보여줌
                     HStack {
                         if isRecommended {
                             StatusTag(
-                                status: activity.tags.first!.contains("Hot") ? .hot(orderCount: nil) : .new
+                                status: activity.tags[0].contains("Hot") ? .hot(orderCount: nil) : .new
                             )
                             Spacer()
                         } else {
                             StatusTag(
-                                status: activity.tags.first! == "Hot 이벤트" ? .hot(orderCount: nil) : .new,
+                                status: activity.tags[0].contains("Hot") ? .hot(orderCount: nil) : .new,
                                 isLongTag: true
                             )
                             .offset(y: 16)
@@ -68,7 +69,7 @@ struct ActivityCard: View {
                     }
                 }
                 
-                Text("Detail에서 description을 가져와야 하는데...")
+                Text("\(activity.tags[0]) & \(activity.category)")
                     .font(.Caption.caption1)
                     .foregroundColor(.gray60)
                     .lineLimit(2)

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -12,6 +12,16 @@ struct ActivityCard: View {
     var activity: ActivitySummaryEntity
     var description: String?
     var orderCount: Int?
+    var keepButtonTapped: (Bool) -> Void
+    
+    @State private var isKeep: Bool
+    
+    init(isRecommended: Bool, activity: ActivitySummaryEntity, description: String? = nil, orderCount: Int? = nil, keepButtonTapped: @escaping (Bool) -> Void) {
+        self.isRecommended = isRecommended
+        self.activity = activity
+        self.keepButtonTapped = keepButtonTapped
+        _isKeep = State(initialValue: activity.isKeep)
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -26,9 +36,10 @@ struct ActivityCard: View {
                 
                 VStack {
                     HStack {
-                        Image(activity.isKeep ? .icnLikeFill : .icnLikeEmpty)
+                        Image(isKeep ? .icnLikeFill : .icnLikeEmpty)
                             .asButton {
-                                // TODO: 좋아요 로직
+                                isKeep.toggle()
+                                keepButtonTapped(isKeep)
                             }
                         Spacer()
                         LocationTag(location: activity.country)
@@ -84,8 +95,3 @@ struct ActivityCard: View {
         .frame(maxWidth: isRecommended ? nil : .infinity)
     }
 }
-
-//#Preview {
-//    ActivityCard(isRecommended: true)
-//    ActivityCard(isRecommended: false)
-//}

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ActivityCard: View {
     var isRecommended: Bool
     var activity: ActivitySummaryEntity
+    var description: String?
+    var orderCount: Int?
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -34,8 +36,6 @@ struct ActivityCard: View {
                     
                     Spacer()
                     
-                    // TODO: 여기 로직 수정
-                    // TODO: hot의 orderCount 디테일 통신으로 처리
                     // TODO: detail의 endDate를 통해 countdown 계산 후 특정 기준을 충족할 경우 .deadline을 보여줌
                     HStack {
                         if isRecommended {
@@ -45,7 +45,7 @@ struct ActivityCard: View {
                             Spacer()
                         } else {
                             StatusTag(
-                                status: activity.tags[0].contains("Hot") ? .hot(orderCount: nil) : .new,
+                                status: activity.tags[0].contains("Hot") ? .hot(orderCount: orderCount) : .new,
                                 isLongTag: true
                             )
                             .offset(y: 16)
@@ -69,7 +69,7 @@ struct ActivityCard: View {
                     }
                 }
                 
-                Text("\(activity.tags[0]) & \(activity.category)")
+                Text(description ?? "\(activity.tags[0]) & \(activity.category)")
                     .font(.Caption.caption1)
                     .foregroundColor(.gray60)
                     .lineLimit(2)

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -7,9 +7,9 @@
 
 import SwiftUI
 
-// TODO: Entity를 매개변수로 받아서 실제 데이터 로드
 struct ActivityCard: View {
     var isRecommended: Bool
+    var activity: ActivitySummaryEntity
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -24,23 +24,30 @@ struct ActivityCard: View {
                 
                 VStack {
                     HStack {
-                        Image(.icnLikeEmpty)
+                        Image(activity.isKeep ? .icnLikeFill : .icnLikeEmpty)
                             .asButton {
                                 // TODO: 좋아요 로직
                             }
                         Spacer()
-                        LocationTag(location: "스위스 융프라우")
+                        LocationTag(location: activity.country)
                     }
                     
                     Spacer()
                     
+                    // TODO: hot의 orderCount 디테일 통신으로 처리
+                    // TODO: detail의 endDate를 통해 countdown 계산 후 특정 기준을 충족할 경우 .deadline을 보여줌
                     HStack {
                         if isRecommended {
-                            StatusTag(status: .hot(orderCount: nil))
+                            StatusTag(
+                                status: activity.tags.first!.contains("Hot") ? .hot(orderCount: nil) : .new
+                            )
                             Spacer()
                         } else {
-                            StatusTag(status: .new, isLongTag: true)
-                                .offset(y: 16)
+                            StatusTag(
+                                status: activity.tags.first! == "Hot 이벤트" ? .hot(orderCount: nil) : .new,
+                                isLongTag: true
+                            )
+                            .offset(y: 16)
                         }
                     }
                 }
@@ -49,24 +56,27 @@ struct ActivityCard: View {
             
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 12) {
-                    Text("겨울 새싹 스키 원정대")
+                    Text(activity.title)
                         .font(.Body.body1.bold())
                         .foregroundColor(.gray90)
                         .lineLimit(1)
                     
-                    LikeCountView(likeCount: 387)
+                    LikeCountView(likeCount: activity.keepCount)
                     
                     if !isRecommended {
-                        PointView(point: 200)
+                        PointView(point: activity.pointReward ?? 0)
                     }
                 }
                 
-                Text("끝없이 펼쳐진 슬로프, 자유롭게 바람을 가르는 시간. 초보자 코스부터 짜릿한 파크존까지, 당신이원하는모든덧어쩌구.....야호")
+                Text("Detail에서 description을 가져와야 하는데...")
                     .font(.Caption.caption1)
                     .foregroundColor(.gray60)
                     .lineLimit(2)
                 
-                PriceView(originPrice: 341000, finalPrice: 123000)
+                PriceView(
+                    originPrice: activity.originalPrice,
+                    finalPrice: activity.finalPrice
+                )
             }
         }
         .frame(width: isRecommended ? 240 : nil)
@@ -74,7 +84,7 @@ struct ActivityCard: View {
     }
 }
 
-#Preview {
-    ActivityCard(isRecommended: true)
-    ActivityCard(isRecommended: false)
-}
+//#Preview {
+//    ActivityCard(isRecommended: true)
+//    ActivityCard(isRecommended: false)
+//}

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -16,9 +16,11 @@ struct ActivityCard: View {
     
     @State private var isKeep: Bool
     
-    init(isRecommended: Bool, activity: ActivitySummaryEntity, description: String? = nil, orderCount: Int? = nil, keepButtonTapped: @escaping (Bool) -> Void) {
+    init(isRecommended: Bool, activity: ActivitySummaryEntity, description: String?, orderCount: Int? = nil, keepButtonTapped: @escaping (Bool) -> Void) {
         self.isRecommended = isRecommended
         self.activity = activity
+        self.description = description
+        self.orderCount = orderCount
         self.keepButtonTapped = keepButtonTapped
         _isKeep = State(initialValue: activity.isKeep)
     }

--- a/FLOV/Common/Components/EmptyResultView.swift
+++ b/FLOV/Common/Components/EmptyResultView.swift
@@ -1,0 +1,23 @@
+//
+//  EmptyResultView.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/28/25.
+//
+
+import SwiftUI
+
+struct EmptyResultView: View {
+    var body: some View {
+        VStack {
+            Text("결과를 찾을 수 없습니다")
+                .font(.Caption.caption0)
+                .foregroundStyle(.gray60)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    EmptyResultView()
+}

--- a/FLOV/Core/AuthManager/AuthManager.swift
+++ b/FLOV/Core/AuthManager/AuthManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@preconcurrency
 final class AuthManager: ObservableObject {
     @Published private(set) var isSigned: Bool
     

--- a/FLOV/Core/DIContainer/DIContainerModifier.swift
+++ b/FLOV/Core/DIContainer/DIContainerModifier.swift
@@ -6,13 +6,16 @@
 //
 
 import SwiftUI
+import Alamofire
 
 struct DIContainerModifier: ViewModifier {
     private let container: DIContainer
     
     init() {
         let authManager = AuthManager()
-        let networkManager = NetworkManager(tokenManager: TokenManager.shared, authManager: authManager)
+        let authInterceptor = AuthInterceptor(tokenManager: TokenManager.shared, authManager: authManager)
+        let session = Session(interceptor: authInterceptor)
+        let networkManager = NetworkManager(tokenManager: TokenManager.shared, authManager: authManager, session: session)
         let authRepository = AuthRepository(networkManager: networkManager, tokenManager: TokenManager.shared)
         let userRepository = UserRepository(networkManager: networkManager, authManager: authManager)
         let activityRepository = ActivityRepository(networkManager: networkManager)

--- a/FLOV/Core/Network/API/Activity/ActivityAPI.swift
+++ b/FLOV/Core/Network/API/Activity/ActivityAPI.swift
@@ -73,27 +73,25 @@ extension ActivityAPI: Router {
         switch self {
         case .fileUpload:
             return [:]
-        case .listLookup(let country, let category, let limit, let next), 
-                .keepLookup(let country, let category, let limit, let next):
-            return [
-                "country": country,
-                "category": category,
-                "limit": limit,
-                "next": next
-            ]
-        case .detailLookup(let id), .keep(let id, _):
-            return [
-                "activity_id": id
-            ]
+        case .listLookup(let country, let category, let limit, let next),
+             .keepLookup(let country, let category, let limit, let next):
+            var parameters: Parameters = [:]
+            if let country = country { parameters["country"] = country }
+            if let category = category { parameters["category"] = category }
+            if let limit = limit { parameters["limit"] = limit }
+            if let next = next { parameters["next"] = next }
+            return parameters
+        case .detailLookup, .keep:
+            return [:]
         case .newListLookup(let country, let category):
-            return [
-                "country": country,
-                "category": category
-            ]
+            var parameters: Parameters = [:]
+            if let country = country { parameters["country"] = country }
+            if let category = category { parameters["category"] = category }
+            return parameters
         case .search(let title):
-            return [
-                "title": title
-            ]
+            var parameters: Parameters = [:]
+            if let title = title { parameters["title"] = title }
+            return parameters
         }
     }
     

--- a/FLOV/Core/Network/API/Activity/ActivityAPI.swift
+++ b/FLOV/Core/Network/API/Activity/ActivityAPI.swift
@@ -10,12 +10,12 @@ import Alamofire
 
 enum ActivityAPI {
     case fileUpload
-    case listLookup(country: String?, category: String?, limit: String?, next: String?)
+    case listLookup(country: String?, category: String?, limit: Int?, next: String?)
     case detailLookup(activityId: String)
     case keep(activityId: String, request: ActivityKeepRequest)
     case newListLookup(country: String?, category: String?)
     case search(title: String?)
-    case keepLookup(country: String?, category: String?, limit: String?, next: String?)
+    case keepLookup(country: String?, category: String?, limit: Int?, next: String?)
 }
 
 extension ActivityAPI: Router {

--- a/FLOV/Core/Network/API/User/UserAPI.swift
+++ b/FLOV/Core/Network/API/User/UserAPI.swift
@@ -94,6 +94,15 @@ extension UserAPI: Router {
         }
     }
     
+    var encoding: ParameterEncoding? {
+        switch self {
+        case .searchUser:
+            return JSONEncoding.default
+        default:
+            return nil
+        }
+    }
+    
     var requestBody: Encodable? {
         switch self {
         case .emailValidate(let request):

--- a/FLOV/Core/Network/DTO/Activity/ActivityDetailLookupAPI.swift
+++ b/FLOV/Core/Network/DTO/Activity/ActivityDetailLookupAPI.swift
@@ -29,8 +29,8 @@ struct ActivityDetailLookupResponse: Decodable {
     let schedule: [ActivitySchedule]?
     let reservationList: [ActivityReservationList]
     let creator: ActivityCreator
-    let createdAt: String
-    let updatedAt: String
+    let createdAt: String?
+    let updatedAt: String?
 
     enum CodingKeys: String, CodingKey {
         case activityId = "activity_id"
@@ -166,8 +166,8 @@ extension ActivityDetailLookupResponse {
                 profileImageURL: creator.profileImage,
                 introduction: creator.introduction
             ),
-            createdAt: createdAt.toDate(format: "yyyy-MM-dd'T'HH:mm:ssZ") ?? Date(),
-            updatedAt: updatedAt.toDate(format: "yyyy-MM-dd'T'HH:mm:ssZ") ?? Date()
+            createdAt: createdAt?.toDate(format: "yyyy-MM-dd'T'HH:mm:ssZ") ?? Date(),
+            updatedAt: updatedAt?.toDate(format: "yyyy-MM-dd'T'HH:mm:ssZ") ?? Date()
         )
     }
 }

--- a/FLOV/Core/Network/DTO/Activity/ActivityListLookupAPI.swift
+++ b/FLOV/Core/Network/DTO/Activity/ActivityListLookupAPI.swift
@@ -78,7 +78,7 @@ extension ActivitySummary {
             finalPrice: price.final,
             tags: tags,
             pointReward: pointReward,
-            isKept: isKeep,
+            isKeep: isKeep,
             keepCount: keepCount
         )
     }

--- a/FLOV/Core/Network/NetworkManager/NetworkManager.swift
+++ b/FLOV/Core/Network/NetworkManager/NetworkManager.swift
@@ -11,8 +11,6 @@ import Alamofire
 protocol NetworkManagerType {
     func callRequest<T: Decodable, U: Router>(_ api: U) async throws -> T
     func uploadMultipart<T: Decodable, U: Router>(_ api: U, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T
-//    func callWithRefresh<T: Decodable>(_ api: Router, as type: T.Type) async throws -> T
-//    func uploadMultipartWithRefresh<T: Decodable>(_ api: Router, as type: T.Type, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T
 }
 
 final class NetworkManager: NetworkManagerType {
@@ -115,81 +113,3 @@ final class NetworkManager: NetworkManagerType {
         }
     }
 }
-
-//extension NetworkManager {
-//    /// 액세스 토큰을 갱신한 이후 요청하는 메서드
-//    func callWithRefresh<T: Decodable>(_ api: Router, as type: T.Type) async throws -> T {
-//        do {
-//            return try await self.callRequest(api)
-//        } catch let error as NetworkError {
-//            switch error {
-//            case .statusCode(419):
-//                break
-//            default:
-//                throw error
-//            }
-//        } catch {
-//            throw error
-//        }
-//        
-//        // 액세스 토큰 갱신
-//        do {
-//            let refreshResponse: RefreshResponse = try await callRequest(AuthAPI.refresh)
-//            tokenManager.updateAuthTokens(
-//                access: refreshResponse.accessToken,
-//                refresh: refreshResponse.refreshToken
-//            )
-//            
-//            return try await self.callRequest(api)
-//        } catch let error as NetworkError {
-//            switch error {
-//            case .statusCode(418):
-//                await authManager.signOut()
-//                throw NetworkError.refreshTokenExpired
-//            default:
-//                throw error
-//            }
-//        } catch {
-//            throw error
-//        }
-//    }
-//}
-//
-//extension NetworkManager {
-//    /// multipart 요청에서 토큰 만료 시 자동 갱신 후 재시도
-//    func uploadMultipartWithRefresh<T: Decodable>(_ api: Router, as type: T.Type, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T {
-//        do {
-//            return try await self.uploadMultipart(api, formDataBuilder: formDataBuilder)
-//        } catch let error as NetworkError {
-//            switch error {
-//            case .statusCode(419):
-//                break
-//            default:
-//                throw error
-//            }
-//        } catch {
-//            throw error
-//        }
-//        
-//        // 액세스 토큰 갱신
-//        do {
-//            let refreshResponse: RefreshResponse = try await callRequest(AuthAPI.refresh)
-//            tokenManager.updateAuthTokens(
-//                access: refreshResponse.accessToken,
-//                refresh: refreshResponse.refreshToken
-//            )
-//            
-//            return try await self.uploadMultipart(api, formDataBuilder: formDataBuilder)
-//        } catch let error as NetworkError {
-//            switch error {
-//            case .statusCode(418):
-//                await authManager.signOut()
-//                throw NetworkError.refreshTokenExpired
-//            default:
-//                throw error
-//            }
-//        } catch {
-//            throw error
-//        }
-//    }
-//}

--- a/FLOV/Core/Network/NetworkManager/NetworkManager.swift
+++ b/FLOV/Core/Network/NetworkManager/NetworkManager.swift
@@ -39,14 +39,14 @@ final class NetworkManager: NetworkManagerType {
         if (200..<300).contains(status) {
             do {
                 let decoded: T = try JSONDecoder().decode(T.self, from: data)
-                NetworkLog.success(url: api.path, statusCode: status, data: decoded)
+                NetworkLog.success(url: dataResponse.response?.url?.absoluteString ?? "", statusCode: status, data: data)
                 return decoded
             } catch {
                 throw NetworkError.decoding(error)
             }
         } else {
             if let errModel = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
-                NetworkLog.failure(url: api.path, statusCode: status, data: errModel)
+                NetworkLog.failure(url: dataResponse.response?.url?.absoluteString ?? "", statusCode: status, data: errModel)
 
                 switch status {
                 case 419:

--- a/FLOV/Core/Network/NetworkManager/NetworkManager.swift
+++ b/FLOV/Core/Network/NetworkManager/NetworkManager.swift
@@ -39,7 +39,7 @@ final class NetworkManager: NetworkManagerType {
         if (200..<300).contains(status) {
             do {
                 let decoded: T = try JSONDecoder().decode(T.self, from: data)
-                NetworkLog.success(url: dataResponse.response?.url?.absoluteString ?? "", statusCode: status, data: data)
+                NetworkLog.success(url: dataResponse.response?.url?.absoluteString ?? "", statusCode: status, data: decoded)
                 return decoded
             } catch {
                 throw NetworkError.decoding(error)

--- a/FLOV/Core/Network/NetworkManager/NetworkManager.swift
+++ b/FLOV/Core/Network/NetworkManager/NetworkManager.swift
@@ -11,22 +11,24 @@ import Alamofire
 protocol NetworkManagerType {
     func callRequest<T: Decodable, U: Router>(_ api: U) async throws -> T
     func uploadMultipart<T: Decodable, U: Router>(_ api: U, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T
-    func callWithRefresh<T: Decodable>(_ api: Router, as type: T.Type) async throws -> T
-    func uploadMultipartWithRefresh<T: Decodable>(_ api: Router, as type: T.Type, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T
+//    func callWithRefresh<T: Decodable>(_ api: Router, as type: T.Type) async throws -> T
+//    func uploadMultipartWithRefresh<T: Decodable>(_ api: Router, as type: T.Type, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T
 }
 
 final class NetworkManager: NetworkManagerType {
     private let tokenManager: TokenManager
     private let authManager: AuthManager
+    private let session: Session
     
-    init(tokenManager: TokenManager, authManager: AuthManager) {
+    init(tokenManager: TokenManager, authManager: AuthManager, session: Session) {
         self.tokenManager = tokenManager
         self.authManager = authManager
+        self.session = session
     }
     
     func callRequest<T: Decodable, U: Router>(_ api: U) async throws -> T {
-        // 서버 응답(Data + HTTPURLResponse)
-        let dataResponse = await AF.request(api)
+        let dataResponse = await session.request(api)
+            .validate(statusCode: 200..<300) // 이 외의 오류는 AFError로 던짐
             .serializingData()
             .response
         
@@ -47,11 +49,16 @@ final class NetworkManager: NetworkManagerType {
         } else {
             if let errModel = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
                 NetworkLog.failure(url: api.path, statusCode: status, data: errModel)
+
                 switch status {
-                case 418:
-                    throw NetworkError.statusCode(418)
                 case 419:
-                    throw NetworkError.statusCode(419)
+                    if let afError = dataResponse.error {
+                        throw afError
+                    } else {
+                        throw AFError.responseValidationFailed(
+                            reason: .unacceptableStatusCode(code: status)
+                        )
+                    }
                 default:
                     throw NetworkError.apiError(errModel.message)
                 }
@@ -63,10 +70,11 @@ final class NetworkManager: NetworkManagerType {
     
     func uploadMultipart<T: Decodable, U: Router>(_ api: U, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T {
         // Multipart 업로드 요청 → Data + HTTPURLResponse 수신
-        let dataResponse = await AF.upload(
+        let dataResponse = await session.upload(
             multipartFormData: formDataBuilder,
             with: try api.asURLRequest()
         )
+            .validate(statusCode: 200..<300) // 이 외의 오류는 AFError로 던짐
             .serializingData()
             .response
         
@@ -79,18 +87,25 @@ final class NetworkManager: NetworkManagerType {
         // 상태코드 분기처리
         if (200..<300).contains(status) {
             do {
-                return try JSONDecoder().decode(T.self, from: data)
+                let decoded: T = try JSONDecoder().decode(T.self, from: data)
+                NetworkLog.success(url: api.path, statusCode: status, data: decoded)
+                return decoded
             } catch {
                 throw NetworkError.decoding(error)
             }
         } else {
             if let errModel = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
                 NetworkLog.failure(url: api.path, statusCode: status, data: errModel)
+
                 switch status {
-                case 418:
-                    throw NetworkError.statusCode(418)
                 case 419:
-                    throw NetworkError.statusCode(419)
+                    if let afError = dataResponse.error {
+                        throw afError
+                    } else {
+                        throw AFError.responseValidationFailed(
+                            reason: .unacceptableStatusCode(code: status)
+                        )
+                    }
                 default:
                     throw NetworkError.apiError(errModel.message)
                 }
@@ -101,80 +116,80 @@ final class NetworkManager: NetworkManagerType {
     }
 }
 
-extension NetworkManager {
-    /// 액세스 토큰을 갱신한 이후 요청하는 메서드
-    func callWithRefresh<T: Decodable>(_ api: Router, as type: T.Type) async throws -> T {
-        do {
-            return try await self.callRequest(api)
-        } catch let error as NetworkError {
-            switch error {
-            case .statusCode(419):
-                break
-            default:
-                throw error
-            }
-        } catch {
-            throw error
-        }
-        
-        // 액세스 토큰 갱신
-        do {
-            let refreshResponse: RefreshResponse = try await callRequest(AuthAPI.refresh)
-            tokenManager.updateAuthTokens(
-                access: refreshResponse.accessToken,
-                refresh: refreshResponse.refreshToken
-            )
-            
-            return try await self.callRequest(api)
-        } catch let error as NetworkError {
-            switch error {
-            case .statusCode(418):
-                await authManager.signOut()
-                throw NetworkError.refreshTokenExpired
-            default:
-                throw error
-            }
-        } catch {
-            throw error
-        }
-    }
-}
-
-extension NetworkManager {
-    /// multipart 요청에서 토큰 만료 시 자동 갱신 후 재시도
-    func uploadMultipartWithRefresh<T: Decodable>(_ api: Router, as type: T.Type, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T {
-        do {
-            return try await self.uploadMultipart(api, formDataBuilder: formDataBuilder)
-        } catch let error as NetworkError {
-            switch error {
-            case .statusCode(419):
-                break
-            default:
-                throw error
-            }
-        } catch {
-            throw error
-        }
-        
-        // 액세스 토큰 갱신
-        do {
-            let refreshResponse: RefreshResponse = try await callRequest(AuthAPI.refresh)
-            tokenManager.updateAuthTokens(
-                access: refreshResponse.accessToken,
-                refresh: refreshResponse.refreshToken
-            )
-            
-            return try await self.uploadMultipart(api, formDataBuilder: formDataBuilder)
-        } catch let error as NetworkError {
-            switch error {
-            case .statusCode(418):
-                await authManager.signOut()
-                throw NetworkError.refreshTokenExpired
-            default:
-                throw error
-            }
-        } catch {
-            throw error
-        }
-    }
-}
+//extension NetworkManager {
+//    /// 액세스 토큰을 갱신한 이후 요청하는 메서드
+//    func callWithRefresh<T: Decodable>(_ api: Router, as type: T.Type) async throws -> T {
+//        do {
+//            return try await self.callRequest(api)
+//        } catch let error as NetworkError {
+//            switch error {
+//            case .statusCode(419):
+//                break
+//            default:
+//                throw error
+//            }
+//        } catch {
+//            throw error
+//        }
+//        
+//        // 액세스 토큰 갱신
+//        do {
+//            let refreshResponse: RefreshResponse = try await callRequest(AuthAPI.refresh)
+//            tokenManager.updateAuthTokens(
+//                access: refreshResponse.accessToken,
+//                refresh: refreshResponse.refreshToken
+//            )
+//            
+//            return try await self.callRequest(api)
+//        } catch let error as NetworkError {
+//            switch error {
+//            case .statusCode(418):
+//                await authManager.signOut()
+//                throw NetworkError.refreshTokenExpired
+//            default:
+//                throw error
+//            }
+//        } catch {
+//            throw error
+//        }
+//    }
+//}
+//
+//extension NetworkManager {
+//    /// multipart 요청에서 토큰 만료 시 자동 갱신 후 재시도
+//    func uploadMultipartWithRefresh<T: Decodable>(_ api: Router, as type: T.Type, formDataBuilder: @escaping (MultipartFormData) -> Void) async throws -> T {
+//        do {
+//            return try await self.uploadMultipart(api, formDataBuilder: formDataBuilder)
+//        } catch let error as NetworkError {
+//            switch error {
+//            case .statusCode(419):
+//                break
+//            default:
+//                throw error
+//            }
+//        } catch {
+//            throw error
+//        }
+//        
+//        // 액세스 토큰 갱신
+//        do {
+//            let refreshResponse: RefreshResponse = try await callRequest(AuthAPI.refresh)
+//            tokenManager.updateAuthTokens(
+//                access: refreshResponse.accessToken,
+//                refresh: refreshResponse.refreshToken
+//            )
+//            
+//            return try await self.uploadMultipart(api, formDataBuilder: formDataBuilder)
+//        } catch let error as NetworkError {
+//            switch error {
+//            case .statusCode(418):
+//                await authManager.signOut()
+//                throw NetworkError.refreshTokenExpired
+//            default:
+//                throw error
+//            }
+//        } catch {
+//            throw error
+//        }
+//    }
+//}

--- a/FLOV/Core/Network/Repository/ActivityRepository.swift
+++ b/FLOV/Core/Network/Repository/ActivityRepository.swift
@@ -26,10 +26,7 @@ final class ActivityRepository: ActivityRepositoryType {
     }
 
     func fileUpload(data: Data) async throws -> ActivityFileUploadEntity {
-        let response: ActivityFileUploadResponse = try await networkManager.uploadMultipartWithRefresh(
-            ActivityAPI.fileUpload,
-            as: ActivityFileUploadResponse.self
-        ) { form in
+        let response: ActivityFileUploadResponse = try await networkManager.uploadMultipart(ActivityAPI.fileUpload) { form in
             form.append(
                 data,
                 withName: "profile",
@@ -44,12 +41,14 @@ final class ActivityRepository: ActivityRepositoryType {
     }
 
     func listLookup(country: String?, category: String?, limit: Int?, next: String?) async throws -> ActivityListEntity {
-        let response: ActivityListLookupResponse = try await networkManager.callWithRefresh(ActivityAPI.listLookup(
+        
+        
+        let response: ActivityListLookupResponse = try await networkManager.callRequest(ActivityAPI.listLookup(
             country: country,
             category: category,
             limit: limit,
             next: next
-        ), as: ActivityListLookupResponse.self)
+        ))
         
         let entity = response.toEntity()
         
@@ -57,7 +56,7 @@ final class ActivityRepository: ActivityRepositoryType {
     }
 
     func detailLookup(activityId: String) async throws -> ActivityDetailEntity {
-        let response: ActivityDetailLookupResponse = try await networkManager.callWithRefresh(ActivityAPI.detailLookup(activityId: activityId), as: ActivityDetailLookupResponse.self)
+        let response: ActivityDetailLookupResponse = try await networkManager.callRequest(ActivityAPI.detailLookup(activityId: activityId))
         
         let entity = response.toEntity()
         
@@ -65,7 +64,7 @@ final class ActivityRepository: ActivityRepositoryType {
     }
 
     func keep(activityId: String, request: ActivityKeepRequest) async throws -> ActivityKeepEntity {
-        let response: ActivityKeepResponse = try await networkManager.callWithRefresh(ActivityAPI.keep(activityId: activityId, request: request), as: ActivityKeepResponse.self)
+        let response: ActivityKeepResponse = try await networkManager.callRequest(ActivityAPI.keep(activityId: activityId, request: request))
         
         let entity = response.toEntity()
         
@@ -73,7 +72,7 @@ final class ActivityRepository: ActivityRepositoryType {
     }
 
     func newListLookup(country: String?, category: String?) async throws -> ActivityListEntity {
-        let response: ActivityNewListLookupResponse = try await networkManager.callWithRefresh(ActivityAPI.newListLookup(country: country, category: category), as: ActivityNewListLookupResponse.self)
+        let response: ActivityNewListLookupResponse = try await networkManager.callRequest(ActivityAPI.newListLookup(country: country, category: category))
         
         let entity = response.toEntity()
         
@@ -81,7 +80,7 @@ final class ActivityRepository: ActivityRepositoryType {
     }
 
     func search(title: String?) async throws -> ActivityListEntity {
-        let response: ActivitySearchResponse = try await networkManager.callWithRefresh(ActivityAPI.search(title: title), as: ActivitySearchResponse.self)
+        let response: ActivitySearchResponse = try await networkManager.callRequest(ActivityAPI.search(title: title))
         
         let entity = response.toEntity()
         
@@ -89,12 +88,12 @@ final class ActivityRepository: ActivityRepositoryType {
     }
 
     func keepLookup(country: String?, category: String?, limit: Int?, next: String?) async throws -> ActivityListEntity {
-        let response: ActivityKeepLookupResponse = try await networkManager.callWithRefresh(ActivityAPI.keepLookup(
+        let response: ActivityKeepLookupResponse = try await networkManager.callRequest(ActivityAPI.keepLookup(
             country: country,
             category: category,
             limit: limit,
             next: next
-        ), as: ActivityKeepLookupResponse.self)
+        ))
         
         let entity = response.toEntity()
         

--- a/FLOV/Core/Network/Repository/ActivityRepository.swift
+++ b/FLOV/Core/Network/Repository/ActivityRepository.swift
@@ -10,12 +10,12 @@ import Alamofire
 
 protocol ActivityRepositoryType {
     func fileUpload(data: Data) async throws -> ActivityFileUploadEntity
-    func listLookup(country: String?, category: String?, limit: String?, next: String?) async throws -> ActivityListEntity
+    func listLookup(country: String?, category: String?, limit: Int?, next: String?) async throws -> ActivityListEntity
     func detailLookup(activityId: String) async throws -> ActivityDetailEntity
     func keep(activityId: String, request: ActivityKeepRequest) async throws -> ActivityKeepEntity
     func newListLookup(country: String?, category: String?) async throws -> ActivityListEntity
     func search(title: String?) async throws -> ActivityListEntity
-    func keepLookup(country: String?, category: String?, limit: String?, next: String?) async throws -> ActivityListEntity
+    func keepLookup(country: String?, category: String?, limit: Int?, next: String?) async throws -> ActivityListEntity
 }
 
 final class ActivityRepository: ActivityRepositoryType {
@@ -43,7 +43,7 @@ final class ActivityRepository: ActivityRepositoryType {
         return entity
     }
 
-    func listLookup(country: String?, category: String?, limit: String?, next: String?) async throws -> ActivityListEntity {
+    func listLookup(country: String?, category: String?, limit: Int?, next: String?) async throws -> ActivityListEntity {
         let response: ActivityListLookupResponse = try await networkManager.callWithRefresh(ActivityAPI.listLookup(
             country: country,
             category: category,
@@ -88,7 +88,7 @@ final class ActivityRepository: ActivityRepositoryType {
         return entity
     }
 
-    func keepLookup(country: String?, category: String?, limit: String?, next: String?) async throws -> ActivityListEntity {
+    func keepLookup(country: String?, category: String?, limit: Int?, next: String?) async throws -> ActivityListEntity {
         let response: ActivityKeepLookupResponse = try await networkManager.callWithRefresh(ActivityAPI.keepLookup(
             country: country,
             category: category,

--- a/FLOV/Core/Network/Repository/UserRepository.swift
+++ b/FLOV/Core/Network/Repository/UserRepository.swift
@@ -93,11 +93,11 @@ final class UserRepository: UserRepositoryType {
     }
     
     func deviceTokenUpdate(request: DeviceTokenUpdateRequest) async throws {
-        _ = try await networkManager.callWithRefresh(UserAPI.deviceTokenUpdate(request: request), as: EmptyResponse.self)
+        _ = try await networkManager.callRequest(UserAPI.deviceTokenUpdate(request: request)) as EmptyResponse
     }
     
     func profileLookup() async throws -> UserEntity {
-        let response: ProfileLookupResponse = try await networkManager.callWithRefresh(UserAPI.profileLookup, as: ProfileLookupResponse.self)
+        let response: ProfileLookupResponse = try await networkManager.callRequest(UserAPI.profileLookup)
         
         let entity = response.toEntity()
         
@@ -105,7 +105,7 @@ final class UserRepository: UserRepositoryType {
     }
     
     func profileUpdate(request: ProfileUpdateRequest) async throws -> UserEntity {
-        let response: ProfileUpdateResponse = try await networkManager.callWithRefresh(UserAPI.profileUpdate(request: request), as: ProfileUpdateResponse.self)
+        let response: ProfileUpdateResponse = try await networkManager.callRequest(UserAPI.profileUpdate(request: request))
         
         let entity = response.toEntity()
         
@@ -113,10 +113,7 @@ final class UserRepository: UserRepositoryType {
     }
     
     func profileImageUpload(data: Data) async throws -> ProfileImageEntity {
-        let response: ProfileImageUploadResponse = try await networkManager.uploadMultipartWithRefresh(
-            UserAPI.profileImageUpload,
-            as: ProfileImageUploadResponse.self
-        ) { form in
+        let response: ProfileImageUploadResponse = try await networkManager.uploadMultipart(UserAPI.profileImageUpload) { form in
             form.append(
                 data,
                 withName: "profile",
@@ -131,7 +128,7 @@ final class UserRepository: UserRepositoryType {
     }
     
     func searchUser(_ nick: String) async throws -> [UserEntity] {
-        let response: SearchUserResponse = try await networkManager.callWithRefresh(UserAPI.searchUser(nick: nick), as: SearchUserResponse.self)
+        let response: SearchUserResponse = try await networkManager.callRequest(UserAPI.searchUser(nick: nick))
         
         let entity = response.toEntity()
         

--- a/FLOV/Core/Network/Token/AuthInterceptor.swift
+++ b/FLOV/Core/Network/Token/AuthInterceptor.swift
@@ -1,0 +1,112 @@
+//
+//  AuthInterceptor.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/26/25.
+//
+
+import Foundation
+import Alamofire
+
+// MARK: - Auth Interceptor
+final class AuthInterceptor: RequestInterceptor, @unchecked Sendable {
+    private let tokenManager: TokenManager
+    private let authManager: AuthManager
+    
+    // 토큰 갱신 동기화를 위한 프로퍼티들
+    private let refreshQueue = DispatchQueue(label: "auth.refresh.queue", qos: .userInitiated)
+    private var isRefreshing = false
+    private var requestsToRetry: [(RetryResult) -> Void] = []
+    
+    init(tokenManager: TokenManager, authManager: AuthManager) {
+        self.tokenManager = tokenManager
+        self.authManager = authManager
+    }
+    
+    // MARK: - RequestAdapter
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        var urlRequest = urlRequest
+        
+        // 인증이 필요한 요청에 액세스 토큰 추가
+        if let accessToken = tokenManager.accessToken {
+            urlRequest.setValue(accessToken, forHTTPHeaderField: "Authorization")
+        }
+        
+        completion(.success(urlRequest))
+    }
+    
+    // MARK: - RequestRetrier
+    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        refreshQueue.async {
+            // 419 에러(토큰 만료)인지 확인
+            guard let response = request.task?.response as? HTTPURLResponse,
+                  response.statusCode == 419 else {
+                completion(.doNotRetry)
+                return
+            }
+            
+            // 이미 토큰 갱신 중이라면 대기열에 추가
+            if self.isRefreshing {
+                self.requestsToRetry.append(completion)
+                return
+            }
+            
+            // 토큰 갱신 시작
+            self.isRefreshing = true
+            self.refreshToken { [weak self] success in
+                guard let self = self else { return }
+                
+                self.refreshQueue.async {
+                    self.isRefreshing = false
+                    
+                    if success {
+                        // 현재 요청과 대기 중인 모든 요청 재시도
+                        completion(.retry)
+                        for retryCompletion in self.requestsToRetry {
+                            retryCompletion(.retry)
+                        }
+                    } else {
+                        // 모든 요청 실패 처리
+                        completion(.doNotRetry)
+                        for retryCompletion in self.requestsToRetry {
+                            retryCompletion(.doNotRetry)
+                        }
+                    }
+                    
+                    self.requestsToRetry.removeAll()
+                }
+            }
+        }
+    }
+    
+    // MARK: - Private Methods
+    private func refreshToken(completion: @escaping (Bool) -> Void) {
+        print("[AuthInterceptor] 🔄 시작 – refreshToken 호출")
+        guard tokenManager.refreshToken != nil else {
+            print("[AuthInterceptor] 🔴 no refresh token")
+            completion(false)
+            return
+        }
+
+        AF.request(AuthAPI.refresh)
+          .validate(statusCode: 200..<300)
+          .responseDecodable(of: RefreshResponse.self) { [weak self] response in
+            switch response.result {
+            case .success(let dto):
+                print("[AuthInterceptor] ✅ refresh 성공: \(dto.accessToken)")
+                self?.tokenManager.updateAuthTokens(
+                  access: dto.accessToken,
+                  refresh: dto.refreshToken
+                )
+                completion(true)
+
+            case .failure(let error):
+                print("[AuthInterceptor] 🔴 refresh 실패:", error)
+                if response.response?.statusCode == 418 {
+                    Task { await self?.authManager.signOut() }
+                }
+                completion(false)
+            }
+          }
+    }
+}

--- a/FLOV/Core/Network/Token/AuthInterceptor.swift
+++ b/FLOV/Core/Network/Token/AuthInterceptor.swift
@@ -87,26 +87,26 @@ final class AuthInterceptor: RequestInterceptor, @unchecked Sendable {
             completion(false)
             return
         }
-
+        
         AF.request(AuthAPI.refresh)
-          .validate(statusCode: 200..<300)
-          .responseDecodable(of: RefreshResponse.self) { [weak self] response in
-            switch response.result {
-            case .success(let dto):
-                print("[AuthInterceptor] ✅ refresh 성공: \(dto.accessToken)")
-                self?.tokenManager.updateAuthTokens(
-                  access: dto.accessToken,
-                  refresh: dto.refreshToken
-                )
-                completion(true)
-
-            case .failure(let error):
-                print("[AuthInterceptor] 🔴 refresh 실패:", error)
-                if response.response?.statusCode == 418 {
-                    Task { await self?.authManager.signOut() }
+            .validate(statusCode: 200..<300)
+            .responseDecodable(of: RefreshResponse.self) { [weak self] response in
+                switch response.result {
+                case .success(let dto):
+                    print("[AuthInterceptor] ✅ refresh 성공: \(dto.accessToken)")
+                    self?.tokenManager.updateAuthTokens(
+                        access: dto.accessToken,
+                        refresh: dto.refreshToken
+                    )
+                    completion(true)
+                    
+                case .failure(let error):
+                    print("[AuthInterceptor] 🔴 refresh 실패:", error)
+                    if response.response?.statusCode == 418 {
+                        Task { await self?.authManager.signOut() }
+                    }
+                    completion(false)
                 }
-                completion(false)
             }
-          }
     }
 }

--- a/FLOV/Core/Network/Token/KeychainManager.swift
+++ b/FLOV/Core/Network/Token/KeychainManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Security
 
-final class KeychainManager {
+final class KeychainManager: Sendable {
     static let shared = KeychainManager()
     private init() {}
     

--- a/FLOV/Core/Network/Token/TokenManager.swift
+++ b/FLOV/Core/Network/Token/TokenManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class TokenManager {
+final class TokenManager: Sendable {
     static let shared = TokenManager()
     private let keychain = KeychainManager.shared
 

--- a/FLOV/Domain/Constant/Filter.swift
+++ b/FLOV/Domain/Constant/Filter.swift
@@ -79,4 +79,13 @@ enum ActivityType: CaseIterable {
             return "랜덤"
         }
     }
+    
+    var query: String {
+        switch self {
+        case .sightseeing, .tour, .package, .exciting, .experience:
+            return title
+        case .random:
+            return ["관광", "투어", "패키지", "익사이팅", "체험"].randomElement()!
+        }
+    }
 }

--- a/FLOV/Domain/Entity/Activity/ActivitySummaryEntity.swift
+++ b/FLOV/Domain/Entity/Activity/ActivitySummaryEntity.swift
@@ -18,6 +18,6 @@ struct ActivitySummaryEntity {
     let finalPrice: Int
     let tags: [String]
     let pointReward: Int?
-    var isKept: Bool
+    var isKeep: Bool
     var keepCount: Int
 }

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -38,6 +38,7 @@ struct ActivityView: View {
         }
         .onAppear {
             viewModel.action(.fetchNewActivities)
+            viewModel.action(.fetchRecommendedActivities)
             viewModel.action(.fetchAllActivities)
         }
     }
@@ -52,8 +53,9 @@ private extension ActivityView {
             if viewModel.output.isLoadingNew {
                 ProgressView()
                     .frame(height: 300)
+            } else {
+                newActivityCarousel()
             }
-            newActivityCarousel()
         }
     }
     
@@ -108,6 +110,7 @@ private extension ActivityView {
                         }
                         .frame(width: cardWidth, height: cardHeight)
                         .onAppear {
+                            // TODO: Detail 과호출문제 해결
                             // viewModel.action(.fetchActivityDetail(id: activity.id))
                         }
                     }
@@ -178,8 +181,8 @@ private extension ActivityView {
     func recommendedActivityList() -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 20) {
-                ForEach(0..<5) { _ in
-                    ActivityCard(isRecommended: true)
+                ForEach(viewModel.output.recommendedActivities, id: \.id) { activity in
+                    ActivityCard(isRecommended: true, activity: activity)
                 }
             }
             .padding()
@@ -197,8 +200,9 @@ private extension ActivityView {
             if viewModel.output.isLoadingAll {
                 ProgressView()
                     .frame(maxWidth: .infinity, minHeight: 200)
+            } else {
+                allActivityList()
             }
-            allActivityList()
         }
     }
     
@@ -276,8 +280,8 @@ private extension ActivityView {
     
     func allActivityList() -> some View {
         VStack(spacing: 20) {
-            ForEach(0..<5) { _ in
-                ActivityCard(isRecommended: false)
+            ForEach(viewModel.output.allActivities, id: \.id) { activity in
+                ActivityCard(isRecommended: false, activity: activity)
             }
         }
         .padding()

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -37,6 +37,7 @@ struct ActivityView: View {
             }
         }
         .onAppear {
+            viewModel.action(.fetchNewActivities)
             viewModel.action(.fetchAllActivities)
         }
     }
@@ -47,6 +48,11 @@ private extension ActivityView {
     func newActivityView() -> some View {
         VStack {
             newActivityHeader()
+            
+            if viewModel.output.isLoadingNew {
+                ProgressView()
+                    .frame(height: 300)
+            }
             newActivityCarousel()
         }
     }
@@ -92,10 +98,17 @@ private extension ActivityView {
                                 .frame(width: cardWidth, height: cardHeight)
                                 .scaleEffect(scale)
                                 .animation(.easeOut(duration: 0.25), value: scale)
+                                .overlay {
+                                    if viewModel.output.loadingDetails.contains(activity.id) {
+                                        ProgressView()
+                                            .scaleEffect(0.8)
+                                            .padding()
+                                    }
+                                }
                         }
                         .frame(width: cardWidth, height: cardHeight)
                         .onAppear {
-                            viewModel.action(.fetchActivityDetail(id: activity.id))
+                            // viewModel.action(.fetchActivityDetail(id: activity.id))
                         }
                     }
                 }
@@ -180,6 +193,11 @@ private extension ActivityView {
         VStack {
             allActivityHeader()
             filterButtonsView()
+            
+            if viewModel.output.isLoadingAll {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 200)
+            }
             allActivityList()
         }
     }

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -89,7 +89,7 @@ private extension ActivityView {
             let sidePadding = (screenWidth - cardWidth) / 2
 
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: spacing) {
+                LazyHStack(spacing: spacing) {
                     ForEach(viewModel.output.newActivities, id: \.id) { activity in
                         GeometryReader { itemGeo in
                             let midX = itemGeo.frame(in: .global).midX
@@ -110,8 +110,7 @@ private extension ActivityView {
                         }
                         .frame(width: cardWidth, height: cardHeight)
                         .onAppear {
-                            // TODO: Detail 과호출문제 해결
-                            // viewModel.action(.fetchActivityDetail(id: activity.id))
+                             viewModel.action(.fetchActivityDetail(id: activity.id))
                         }
                     }
                 }
@@ -180,9 +179,12 @@ private extension ActivityView {
     
     func recommendedActivityList() -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 20) {
+            LazyHStack(spacing: 20) {
                 ForEach(viewModel.output.recommendedActivities, id: \.id) { activity in
-                    ActivityCard(isRecommended: true, activity: activity)
+                    ActivityCard(isRecommended: true, activity: activity, description: viewModel.output.activityDetails[activity.id]?.description)
+                        .onAppear {
+                            viewModel.action(.fetchActivityDetail(id: activity.id))
+                        }
                 }
             }
             .padding()
@@ -281,9 +283,20 @@ private extension ActivityView {
     }
     
     func allActivityList() -> some View {
-        VStack(spacing: 20) {
+        LazyVStack(spacing: 20) {
             ForEach(viewModel.output.allActivities, id: \.id) { activity in
-                ActivityCard(isRecommended: false, activity: activity)
+                let description = viewModel.output.activityDetails[activity.id]?.description
+                let orderCount = viewModel.output.activityDetails[activity.id]?.totalOrderCount
+                
+                ActivityCard(
+                    isRecommended: false,
+                    activity: activity,
+                    description: description,
+                    orderCount: orderCount
+                )
+                    .onAppear {
+                        viewModel.action(.fetchActivityDetail(id: activity.id))
+                    }
             }
         }
         .padding()

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -181,7 +181,7 @@ private extension ActivityView {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: 20) {
                 ForEach(viewModel.output.recommendedActivities, id: \.id) { activity in
-                    // TODO: 전체 ActivityCard와 상태 공유 X => ActivityCard자체의 뷰모델이 필요할듯
+                    // TODO: 전체 ActivityCard와 상태 공유 X
                     ActivityCard(isRecommended: true, activity: activity, description: viewModel.output.activityDetails[activity.id]?.description) { isKeep in
                         viewModel.action(.keepToggle(id: activity.id, keepStatus: isKeep))
                     }

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -181,7 +181,10 @@ private extension ActivityView {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: 20) {
                 ForEach(viewModel.output.recommendedActivities, id: \.id) { activity in
-                    ActivityCard(isRecommended: true, activity: activity, description: viewModel.output.activityDetails[activity.id]?.description)
+                    // TODO: 전체 ActivityCard와 상태 공유 X => ActivityCard자체의 뷰모델이 필요할듯
+                    ActivityCard(isRecommended: true, activity: activity, description: viewModel.output.activityDetails[activity.id]?.description) { isKeep in
+                        viewModel.action(.keepToggle(id: activity.id, keepStatus: isKeep))
+                    }
                         .onAppear {
                             viewModel.action(.fetchActivityDetail(id: activity.id))
                         }
@@ -293,7 +296,9 @@ private extension ActivityView {
                     activity: activity,
                     description: description,
                     orderCount: orderCount
-                )
+                ) { isKeep in
+                    viewModel.action(.keepToggle(id: activity.id, keepStatus: isKeep))
+                }
                     .onAppear {
                         viewModel.action(.fetchActivityDetail(id: activity.id))
                     }

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -200,6 +200,8 @@ private extension ActivityView {
             if viewModel.output.isLoadingAll {
                 ProgressView()
                     .frame(maxWidth: .infinity, minHeight: 200)
+            } else if viewModel.output.allActivities.isEmpty {
+                EmptyResultView()
             } else {
                 allActivityList()
             }

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -70,9 +70,6 @@ private extension ActivityView {
     }
     
     func newActivityCarousel() -> some View {
-        // TODO: 실제 activity데이터로 변경
-        let colors: [Color] = [.red, .green, .blue, .orange, .purple]
-        
         let cardWidthRatio: CGFloat = 0.8 // 화면 너비의 80%
         let cardHeight: CGFloat = 300
         let spacing: CGFloat = -30 // 카드 사이 간격
@@ -85,18 +82,21 @@ private extension ActivityView {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: spacing) {
-                    ForEach(colors.indices, id: \.self) { idx in
+                    ForEach(viewModel.output.newActivities, id: \.id) { activity in
                         GeometryReader { itemGeo in
                             let midX = itemGeo.frame(in: .global).midX
                             let distance = abs(midX - screenWidth/2)
                             let scale = max(minScale, 1 - distance / screenWidth)
                             
-                            newActivityCard(colors: colors, idx: idx)
+                            newActivityCard(activity: activity)
                                 .frame(width: cardWidth, height: cardHeight)
                                 .scaleEffect(scale)
                                 .animation(.easeOut(duration: 0.25), value: scale)
                         }
                         .frame(width: cardWidth, height: cardHeight)
+                        .onAppear {
+                            viewModel.action(.fetchActivityDetail(id: activity.id))
+                        }
                     }
                 }
                 .padding(.horizontal, sidePadding)
@@ -105,19 +105,18 @@ private extension ActivityView {
         .frame(height: cardHeight)
     }
     
-    func newActivityCard(colors: [Color], idx: Int) -> some View {
+    func newActivityCard(activity: ActivitySummaryEntity) -> some View {
         RoundedRectangle(cornerRadius: 20)
-            .fill(colors[idx])
             .overlay {
                 VStack(alignment: .leading, spacing: 12) {
                     HStack {
-                        LocationTag(location: "스위스 융프라우")
+                        LocationTag(location: activity.country)
                         Spacer()
                     }
                     
                     Spacer()
                     
-                    Text("겨울 새싹 스키 원정대")
+                    Text(activity.title)
                         .font(.Body.body0)
                         .foregroundStyle(.white)
                         .lineLimit(1)
@@ -127,12 +126,12 @@ private extension ActivityView {
                             .resizable()
                             .frame(width: 16, height: 16)
                         
-                        Text("123,000원")
+                        Text("\(activity.finalPrice)원")
                             .font(.Caption.caption0)
                             .foregroundStyle(.white)
                     }
                     
-                    Text("끝없이 펼쳐진 슬로프, 자유롭게 바람을 가르는 시간. 초보자 코스부터 짜릿한 파크존까지, 당신만의 새싹 스키 리듬을 찾아 떠나보세요.")
+                    Text(viewModel.output.activityDetails[activity.id]?.description ?? "...")
                         .font(.Caption.caption1)
                         .foregroundStyle(.gray30)
                         .lineLimit(3)

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -245,7 +245,7 @@ private extension ActivityView {
                     .background(viewModel.output.selectedCountry == country ? Color.colDeep.opacity(0.5) : Color.white)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(viewModel.output.selectedCountry == country ? Color.colDeep : Color.gray30, lineWidth: 1)
+                            .stroke(viewModel.output.selectedCountry == country ? Color.colDeep : Color.gray30, lineWidth: 2)
                     )
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
@@ -269,7 +269,7 @@ private extension ActivityView {
                         .background(viewModel.output.selectedActivityType == type ? Color.colDeep.opacity(0.5) : Color.white)
                         .overlay(
                             Capsule()
-                                .stroke(viewModel.output.selectedActivityType == type ? Color.colDeep : Color.gray30, lineWidth: 1)
+                                .stroke(viewModel.output.selectedActivityType == type ? Color.colDeep : Color.gray30, lineWidth: 2)
                         )
                         .clipShape(Capsule())
                 }

--- a/FLOV/Feature/02_Activity/ViewModel/ActivityViewModel.swift
+++ b/FLOV/Feature/02_Activity/ViewModel/ActivityViewModel.swift
@@ -109,7 +109,9 @@ extension ActivityViewModel {
         input.fetchAllActivities
             .sink { [weak self] _ in
                 guard let self else { return }
-                self.fetchActivities()
+                Task {
+                    await self.fetchActivities()
+                }
             }
             .store(in: &cancellables)
         
@@ -192,10 +194,18 @@ extension ActivityViewModel {
         }
     }
     
-    private func fetchActivities() {
+    // TODO: country, category, limit, next를 파라미터로 받아서 처리
+    @MainActor
+    private func fetchActivities() async {
         output.isLoadingAll = true
         defer { output.isLoadingAll = false }
         
-        print("fetchActivities")
+        do {
+            let response = try await activityRepository.listLookup(country: nil, category: nil, limit: 10, next: nil)
+            
+            output.allActivities = response.data
+        } catch {
+            print(error)
+        }
     }
 }

--- a/FLOV/Feature/02_Activity/ViewModel/ActivityViewModel.swift
+++ b/FLOV/Feature/02_Activity/ViewModel/ActivityViewModel.swift
@@ -120,7 +120,11 @@ extension ActivityViewModel {
             .store(in: &cancellables)
         
         input.fetchActivityDetail
-            .removeDuplicates { $0 == $1 }
+            .compactMap { [weak self] id -> String? in
+                guard let self = self else { return nil }
+                return self.output.activityDetails[id] == nil ? id : nil
+            }
+            .removeDuplicates()
             .sink { [weak self] id in
                 guard let self else { return }
                 Task {


### PR DESCRIPTION
close #26 

## *⛳️ Work Description*
- AccessToken 갱신 로직을 Interceptor로 변경해 구현했습니다.
- New, 추천, 필터별 액티비티를 불러오는 네트워크 통신을 구현했습니다.
- detailAPI로부터 description과 총 예약수 등을 불러옵니다.
- 좋아요로직을 구현했습니다. => 수정 필요합니다.

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|New, 추천|<img width="250" alt="AppFlow" src="https://github.com/user-attachments/assets/9363afb5-8aae-458b-9680-1bec2bc786c8">|
|필터링(전체)|<img width="250" alt="AppFlow" src="https://github.com/user-attachments/assets/8bc2f505-7938-4c05-a330-b995472d1440">|


## *❓ 고민한 지점*
- AcivityView에서 description의 경우 detailAPI 통신을 한 번 더 해서 받아와야 하는데, 네트워크 요청을 onAppear에서 하다보니 과호출이 발생할 가능성이 높습니다. 어떻게 처리해야 할지 고민이 됩니다.
  - 각 Card가 onAppear될때마다 detail 통신을 하는 action을 보내고 Stack을 Lazy로 선언해 화면에 보이는 뷰만 통신을 하도록 수정해서 과호출을 방지했습니다.
  - Combine의 `.removeDuplicates()`를 통해 이전에 방출된 이벤트와 같은 경우 다시 통신을 하지 않도록 수정해 과호출을 방지했습니다.


- 좋아요 로직 구현 방식은 다음과 같습니다.
  - ActivityCard라는 커스텀뷰에서 좋아요 버튼을 탭했을 때 클로저를 통해 Activty로 보냅니다.
  - ActivityCard내의 좋아요 버튼의 상태를 관리하기 위해 isKeep이라는 @State변수를 통해 UI업데이트를 합니다.
  - 해당 변수를 클로저로 함께 보내고, keep 네트워크를 요청할 때 해당 값을 요청 바디로 보냅니다.
  - 그래서 UI 업데이트와 네트워크 통신을 통한 반영이 다 가능하나, 다음과 같은 고민되는 점이 있습니다.
- 좋아요 로직에서의 고민
  - 네트워크 통신이 되지 않을때 UI만 업데이트되고, 반영은 되지 않는 문제가 발생할 수 있습니다.
  - 추천 액티비티에서 좋아요 버튼을 눌러서 상태가 바뀌었지만, 그 아래 필터링된 전체 액티비티에는 바로 반영이 되지 않습니다. 수정이 필요합니다.
 

## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
