### PR TITLE
[Feat] ActivityView 로직 완성

### DIFF
--- a/FLOV.xcodeproj/project.pbxproj
+++ b/FLOV.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		792CF8942DCFB6BE0074FB34 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 792CF8932DCFB6BE0074FB34 /* .gitignore */; };
 		792CF8962DCFB7FE0074FB34 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 792CF8952DCFB7FE0074FB34 /* Config.xcconfig */; };
+		793178442DE8739700D0CC75 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 793178432DE8739700D0CC75 /* Kingfisher */; };
 		79F4B4C42DD47766008F95BE /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 79F4B4C32DD47766008F95BE /* Alamofire */; };
 		79F4B4C72DD47774008F95BE /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 79F4B4C62DD47774008F95BE /* KakaoSDKAuth */; };
 		79F4B4C92DD47774008F95BE /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 79F4B4C82DD47774008F95BE /* KakaoSDKCommon */; };
@@ -51,6 +52,7 @@
 				79F4B4C42DD47766008F95BE /* Alamofire in Frameworks */,
 				79F4B4C92DD47774008F95BE /* KakaoSDKCommon in Frameworks */,
 				79F4B4C72DD47774008F95BE /* KakaoSDKAuth in Frameworks */,
+				793178442DE8739700D0CC75 /* Kingfisher in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,6 +101,7 @@
 				79F4B4C62DD47774008F95BE /* KakaoSDKAuth */,
 				79F4B4C82DD47774008F95BE /* KakaoSDKCommon */,
 				79F4B4CA2DD47774008F95BE /* KakaoSDKUser */,
+				793178432DE8739700D0CC75 /* Kingfisher */,
 			);
 			productName = FLOV;
 			productReference = 792CF87E2DCFB3880074FB34 /* FLOV.app */;
@@ -131,6 +134,7 @@
 			packageReferences = (
 				79F4B4C22DD47766008F95BE /* XCRemoteSwiftPackageReference "Alamofire" */,
 				79F4B4C52DD47774008F95BE /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
+				793178422DE8739700D0CC75 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 792CF87F2DCFB3880074FB34 /* Products */;
@@ -385,6 +389,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		793178422DE8739700D0CC75 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.3.2;
+			};
+		};
 		79F4B4C22DD47766008F95BE /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire";
@@ -404,6 +416,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		793178432DE8739700D0CC75 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 793178422DE8739700D0CC75 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
+		};
 		79F4B4C32DD47766008F95BE /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 79F4B4C22DD47766008F95BE /* XCRemoteSwiftPackageReference "Alamofire" */;

--- a/FLOV.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FLOV.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fcdb6d5dc76fef3126c97e3f42a1ae0bb40cd2c958e8591ac4547ce131a2698e",
+  "originHash" : "cf45576eea1dc26616087c4233e90e7096bcbd0c93c514510b76b76fcac91ec6",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "787763e335949dfad6b721aa04771e22d04e1493",
         "version" : "2.24.2"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "7deda23bbdca612076c5c315003d8638a08ed0f1",
+        "version" : "8.3.2"
       }
     }
   ],

--- a/FLOV/App/FLOVApp.swift
+++ b/FLOV/App/FLOVApp.swift
@@ -8,12 +8,14 @@
 import SwiftUI
 import KakaoSDKAuth
 import KakaoSDKCommon
+import Kingfisher
 
 @main
 struct FLOVApp: App {
     init() {
         /// KakaoSDK 초기화
         KakaoSDK.initSDK(appKey: Config.kakaoNativeAppKey)
+        KingfisherConfig()
     }
     
     var body: some Scene {
@@ -27,4 +29,11 @@ struct FLOVApp: App {
                 }
         }
     }
+}
+
+private func KingfisherConfig() {
+    let cache = KingfisherManager.shared.cache
+    cache.memoryStorage.config.totalCostLimit = 50 * 1024 * 1024
+    cache.diskStorage.config.sizeLimit = 200 * 1024 * 1024
+    cache.diskStorage.config.expiration = .days(7)
 }

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -34,11 +34,11 @@ struct ActivityCard: View {
                     cachePolicy: .memoryAndDiskWithOriginal,
                     height: isRecommended ? 120 : 180
                 )
-                    .clipShape(RoundedRectangle(cornerRadius: 16))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16)
-                            .stroke(Color.colLight, lineWidth: 4)
-                    )
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Color.colLight, lineWidth: 4)
+                )
                 
                 VStack {
                     HStack {

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -28,9 +28,9 @@ struct ActivityCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ZStack(alignment: .topLeading) {
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(Color.colDeep)
-                    .aspectRatio(16/9, contentMode: .fill)
+                KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 16/9)
+                    .frame(height: isRecommended ? 120 : 180)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
                     .overlay(
                         RoundedRectangle(cornerRadius: 16)
                             .stroke(Color.colLight, lineWidth: 4)
@@ -65,6 +65,7 @@ struct ActivityCard: View {
                         }
                     }
                 }
+                .shadow(radius: 2)
                 .padding(8)
             }
             

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -28,7 +28,7 @@ struct ActivityCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ZStack(alignment: .topLeading) {
-                KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 16/9)
+                KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 16/9, cachePolicy: .memoryAndDisk)
                     .frame(height: isRecommended ? 120 : 180)
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .overlay(

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -28,7 +28,7 @@ struct ActivityCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ZStack(alignment: .topLeading) {
-                KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 16/9, cachePolicy: .memoryAndDisk)
+                KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 16/9, cachePolicy: .memoryAndDiskWithOriginal)
                     .frame(height: isRecommended ? 120 : 180)
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .overlay(

--- a/FLOV/Common/Components/ActivityCard.swift
+++ b/FLOV/Common/Components/ActivityCard.swift
@@ -28,8 +28,12 @@ struct ActivityCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ZStack(alignment: .topLeading) {
-                KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 16/9, cachePolicy: .memoryAndDiskWithOriginal)
-                    .frame(height: isRecommended ? 120 : 180)
+                KFRemoteImageView(
+                    path: activity.thumbnailURLs[0],
+                    aspectRatio: 18/9,
+                    cachePolicy: .memoryAndDiskWithOriginal,
+                    height: isRecommended ? 120 : 180
+                )
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .overlay(
                         RoundedRectangle(cornerRadius: 16)

--- a/FLOV/Core/Extension/KFImage+.swift
+++ b/FLOV/Core/Extension/KFImage+.swift
@@ -1,0 +1,27 @@
+//
+//  KFImage+.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/30/25.
+//
+
+import Foundation
+import Kingfisher
+
+extension KFImage {
+    func configureCache(for policy: CachePolicy) -> KFImage {
+        switch policy {
+        case .memoryOnly:
+            self
+                .cacheMemoryOnly()
+                .diskCacheAccessExtending(.none)
+        case .diskOnly:
+            self
+                .diskCacheExpiration(.days(7))
+        case .memoryAndDiskWithOriginal:
+            self
+                .cacheOriginalImage()
+                .diskCacheExpiration(.days(7))
+        }
+    }
+}

--- a/FLOV/Core/Extension/URL+.swift
+++ b/FLOV/Core/Extension/URL+.swift
@@ -1,0 +1,21 @@
+//
+//  URL+.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/30/25.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+extension URL {
+    var isImageType: Bool {
+        guard let uniformType = UTType(filenameExtension: pathExtension) else { return false }
+        return uniformType.conforms(to: .image)
+    }
+    
+    var isVideoType: Bool {
+        guard let uniformType = UTType(filenameExtension: pathExtension) else { return false }
+        return uniformType.conforms(to: .movie)
+    }
+}

--- a/FLOV/Core/ImageLoader/APIRequestModifier.swift
+++ b/FLOV/Core/ImageLoader/APIRequestModifier.swift
@@ -1,0 +1,28 @@
+//
+//  APIRequestModifier.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/29/25.
+//
+
+import Foundation
+import Kingfisher
+
+struct APIRequestModifier: ImageDownloadRequestModifier {
+    let baseURL: String
+    let apiKey: String
+    let accessToken: String?
+
+    func modified(for request: URLRequest) -> URLRequest? {
+        var r = request
+        r.url = URL(string: baseURL + "/v1" + (request.url?.path ?? ""))!
+        r.setValue(apiKey, forHTTPHeaderField: "SeSACKey")
+        if let token = accessToken {
+            r.setValue(token, forHTTPHeaderField: "Authorization")
+        }
+        // 디버그 로그
+        print("▶️ KF Request URL: \(r.httpMethod ?? "GET") \(r.url?.absoluteString ?? "")")
+        print("▶️ KF Request Headers: \(r.allHTTPHeaderFields ?? [:])")
+        return r
+    }
+}

--- a/FLOV/Core/ImageLoader/APIRequestModifier.swift
+++ b/FLOV/Core/ImageLoader/APIRequestModifier.swift
@@ -9,13 +9,11 @@ import Foundation
 import Kingfisher
 
 struct APIRequestModifier: ImageDownloadRequestModifier {
-    let baseURL: String
     let apiKey: String
     let accessToken: String?
 
     func modified(for request: URLRequest) -> URLRequest? {
         var request = request
-        request.url = URL(string: baseURL + (request.url?.path ?? ""))!
         request.setValue(apiKey, forHTTPHeaderField: "SeSACKey")
         if let token = accessToken {
             request.setValue(token, forHTTPHeaderField: "Authorization")

--- a/FLOV/Core/ImageLoader/APIRequestModifier.swift
+++ b/FLOV/Core/ImageLoader/APIRequestModifier.swift
@@ -14,15 +14,17 @@ struct APIRequestModifier: ImageDownloadRequestModifier {
     let accessToken: String?
 
     func modified(for request: URLRequest) -> URLRequest? {
-        var r = request
-        r.url = URL(string: baseURL + "/v1" + (request.url?.path ?? ""))!
-        r.setValue(apiKey, forHTTPHeaderField: "SeSACKey")
+        var request = request
+        request.url = URL(string: baseURL + (request.url?.path ?? ""))!
+        request.setValue(apiKey, forHTTPHeaderField: "SeSACKey")
         if let token = accessToken {
-            r.setValue(token, forHTTPHeaderField: "Authorization")
+            request.setValue(token, forHTTPHeaderField: "Authorization")
         }
-        // 디버그 로그
-        print("▶️ KF Request URL: \(r.httpMethod ?? "GET") \(r.url?.absoluteString ?? "")")
-        print("▶️ KF Request Headers: \(r.allHTTPHeaderFields ?? [:])")
-        return r
+        
+        #if DEBUG
+        print("▶️ KF Request URL: \(request.httpMethod ?? "GET") \(request.url?.absoluteString ?? "")")
+        print("▶️ KF Request Headers: \(request.allHTTPHeaderFields ?? [:])")
+        #endif
+        return request
     }
 }

--- a/FLOV/Core/ImageLoader/KFRemoteImageView.swift
+++ b/FLOV/Core/ImageLoader/KFRemoteImageView.swift
@@ -12,20 +12,20 @@ struct KFRemoteImageView: View {
     let path: String
     let aspectRatio: CGFloat
     let cachePolicy: CachePolicy
+
     let baseURL = Config.baseURL
     let apiKey = Config.sesacKey
     let accessToken = TokenManager.shared.accessToken
     
-    private var isValidImagePath: Bool {
-        let ext = URL(string: path)?.pathExtension.lowercased() ?? ""
-        return ["jpg", "jpeg", "png"].contains(ext)
+    private var fileExtension: String {
+        URL(string: path)?.pathExtension.lowercased() ?? ""
     }
     
     var body: some View {
         GeometryReader { geometry in
-            if isValidImagePath {
-                KFImage(URL(string: baseURL + path))
-                    // URL 조립·헤더 추가
+            let urlString = URL(string: baseURL + "/v1" + path)!
+            if urlString.isImageType {
+                KFImage(urlString)
                     .requestModifier(APIRequestModifier(baseURL: baseURL, apiKey: apiKey, accessToken: accessToken))
                     .onSuccess { result in
                         print("✅ SUCCESS: \(result.source.url?.absoluteString ?? "")")
@@ -33,61 +33,37 @@ struct KFRemoteImageView: View {
                     .onFailure { error in
                         print("❌ FAILED: \(error) ➕ URL: \(path)")
                     }
-                    // 다운샘플링
                     .downsampling(size: geometry.size)
                     .scaleFactor(UIScreen.main.scale)
                     .configureCache(for: cachePolicy)
                     .loadDiskFileSynchronously(false)
-                    // 로딩 중 placeholder
                     .placeholder { ProgressView() }
-                    // 뷰 사라질 때 네트워크 취소
                     .cancelOnDisappear(true)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: geometry.size.width, height: geometry.size.height)
                     .clipped()
+            } else if urlString.isVideoType {
+                VideoThumbnailLoaderView(
+                    videoURL: urlString,
+                    targetSize: geometry.size,
+                    contentAspectRatio: aspectRatio,
+                    apiKey: apiKey,
+                    accessToken: accessToken
+                )
+                .frame(width: geometry.size.width, height: geometry.size.height)
+                .overlay {
+                    Image(.imgPlay)
+                        .resizable()
+                        .frame(width: 32, height: 32)
+                }
+                .clipped()
             } else {
-                // TODO: AVAssetImageGenerator로 이미지 썸네일로 대체
                 RoundedRectangle(cornerRadius: 8)
                     .foregroundStyle(Color.colBlack)
                     .aspectRatio(contentMode: .fill)
                     .frame(width: geometry.size.width, height: geometry.size.height)
-                    .overlay {
-                        Image(.imgPlay)
-                            .resizable()
-                            .frame(width: 32, height: 32)
-                    }
             }
-        }
-    }
-}
-
-enum CachePolicy {
-    case memoryOnly
-    case diskOnly
-    case memoryAndDisk
-    case memoryAndDiskWithOriginal
-}
-
-extension KFImage {
-    func configureCache(for policy: CachePolicy) -> KFImage {
-        switch policy {
-        case .memoryOnly:
-            self
-                .cacheMemoryOnly()
-                .diskCacheAccessExtending(.none)
-        case .diskOnly:
-            self
-                .cacheMemoryOnly(false)
-                .diskCacheAccessExtending(.expirationTime(.days(7)))
-        case .memoryAndDisk:
-            self
-                .cacheMemoryOnly(false)
-                .diskCacheAccessExtending(.expirationTime(.days(7)))
-        case .memoryAndDiskWithOriginal:
-            self
-                .cacheOriginalImage()
-                .diskCacheAccessExtending(.expirationTime(.days(7)))
         }
     }
 }

--- a/FLOV/Core/ImageLoader/KFRemoteImageView.swift
+++ b/FLOV/Core/ImageLoader/KFRemoteImageView.swift
@@ -1,0 +1,65 @@
+//
+//  KFRemoteImageView.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/29/25.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct KFRemoteImageView: View {
+    let path: String
+    let aspectRatio: CGFloat
+    let baseURL = Config.baseURL
+    let apiKey = Config.sesacKey
+    let accessToken = TokenManager.shared.accessToken
+    
+    private var isValidImagePath: Bool {
+        let ext = URL(string: path)?.pathExtension.lowercased() ?? ""
+        return ["jpg", "jpeg", "png"].contains(ext)
+    }
+    
+    var body: some View {
+        GeometryReader { geometry in
+            if isValidImagePath {
+                KFImage(URL(string: baseURL + path))
+                    // URL 조립·헤더 추가
+                    .requestModifier(APIRequestModifier(baseURL: baseURL, apiKey: apiKey, accessToken: accessToken))
+                    .onSuccess { result in
+                        print("✅ SUCCESS: \(result.source.url?.absoluteString ?? "")")
+                    }
+                    .onFailure { error in
+                        print("❌ FAILED: \(error) ➕ URL: \(path)")
+                    }
+                    // 다운샘플링
+                    .downsampling(size: geometry.size)
+                    .scaleFactor(UIScreen.main.scale)
+                    // 원본 데이터도 디스크에 캐시
+                    .cacheOriginalImage()
+                    // 디스크캐시 만료기한
+                    .diskCacheAccessExtending(ExpirationExtending.expirationTime(.days(7)))
+                    .loadDiskFileSynchronously(false)
+                    // 로딩 중 placeholder
+                    .placeholder { ProgressView() }
+                    // 뷰 사라질 때 네트워크 취소
+                    .cancelOnDisappear(true)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .clipped()
+            } else {
+                // TODO: AVAssetImageGenerator로 이미지 썸네일로 대체
+                RoundedRectangle(cornerRadius: 8)
+                    .foregroundStyle(Color.colBlack)
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .overlay {
+                        Image(.imgPlay)
+                            .resizable()
+                            .frame(width: 32, height: 32)
+                    }
+            }
+        }
+    }
+}

--- a/FLOV/Core/ImageLoader/KFRemoteImageView.swift
+++ b/FLOV/Core/ImageLoader/KFRemoteImageView.swift
@@ -11,6 +11,7 @@ import Kingfisher
 struct KFRemoteImageView: View {
     let path: String
     let aspectRatio: CGFloat
+    let cachePolicy: CachePolicy
     let baseURL = Config.baseURL
     let apiKey = Config.sesacKey
     let accessToken = TokenManager.shared.accessToken
@@ -35,10 +36,7 @@ struct KFRemoteImageView: View {
                     // 다운샘플링
                     .downsampling(size: geometry.size)
                     .scaleFactor(UIScreen.main.scale)
-                    // 원본 데이터도 디스크에 캐시
-                    .cacheOriginalImage()
-                    // 디스크캐시 만료기한
-                    .diskCacheAccessExtending(ExpirationExtending.expirationTime(.days(7)))
+                    .configureCache(for: cachePolicy)
                     .loadDiskFileSynchronously(false)
                     // 로딩 중 placeholder
                     .placeholder { ProgressView() }
@@ -60,6 +58,36 @@ struct KFRemoteImageView: View {
                             .frame(width: 32, height: 32)
                     }
             }
+        }
+    }
+}
+
+enum CachePolicy {
+    case memoryOnly
+    case diskOnly
+    case memoryAndDisk
+    case memoryAndDiskWithOriginal
+}
+
+extension KFImage {
+    func configureCache(for policy: CachePolicy) -> KFImage {
+        switch policy {
+        case .memoryOnly:
+            self
+                .cacheMemoryOnly()
+                .diskCacheAccessExtending(.none)
+        case .diskOnly:
+            self
+                .cacheMemoryOnly(false)
+                .diskCacheAccessExtending(.expirationTime(.days(7)))
+        case .memoryAndDisk:
+            self
+                .cacheMemoryOnly(false)
+                .diskCacheAccessExtending(.expirationTime(.days(7)))
+        case .memoryAndDiskWithOriginal:
+            self
+                .cacheOriginalImage()
+                .diskCacheAccessExtending(.expirationTime(.days(7)))
         }
     }
 }

--- a/FLOV/Core/ImageLoader/KFRemoteImageView.swift
+++ b/FLOV/Core/ImageLoader/KFRemoteImageView.swift
@@ -36,11 +36,7 @@ struct KFRemoteImageView: View {
         
         if url.isImageType {
             KFImage(url)
-                .requestModifier(APIRequestModifier(
-                    baseURL: baseURL,
-                    apiKey: apiKey,
-                    accessToken: accessToken
-                ))
+                .requestModifier(APIRequestModifier(apiKey: apiKey, accessToken: accessToken))
                 .downsampling(size: targetSize)
                 .scaleFactor(UIScreen.main.scale)
                 .configureCache(for: cachePolicy)
@@ -56,7 +52,7 @@ struct KFRemoteImageView: View {
             VideoThumbnailLoaderView(
                 videoURL: url,
                 targetSize: targetSize,
-                contentAspectRatio: aspectRatio,
+                aspectRatio: aspectRatio,
                 apiKey: apiKey,
                 accessToken: accessToken
             )

--- a/FLOV/Core/ImageLoader/VideoThumbnailLoaderView.swift
+++ b/FLOV/Core/ImageLoader/VideoThumbnailLoaderView.swift
@@ -12,7 +12,7 @@ import Kingfisher
 struct VideoThumbnailLoaderView: View {
     let videoURL: URL
     let targetSize: CGSize
-    let contentAspectRatio: CGFloat
+    let aspectRatio: CGFloat
     let apiKey: String
     let accessToken: String?
 

--- a/FLOV/Core/ImageLoader/VideoThumbnailLoaderView.swift
+++ b/FLOV/Core/ImageLoader/VideoThumbnailLoaderView.swift
@@ -1,0 +1,106 @@
+//
+//  VideoThumbnailLoaderView.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/30/25.
+//
+
+import SwiftUI
+import AVFoundation
+import Kingfisher
+
+struct VideoThumbnailLoaderView: View {
+    let videoURL: URL
+    let targetSize: CGSize
+    let contentAspectRatio: CGFloat
+    let apiKey: String
+    let accessToken: String?
+
+    @State private var thumbnailImage: Image?
+    @State private var isLoading = true
+
+    var body: some View {
+        ZStack {
+            if isLoading {
+                ProgressView()
+            } else if let img = thumbnailImage {
+                img
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .foregroundStyle(Color.colBlack)
+                    .overlay {
+                        Image(.imgPlay)
+                            .resizable()
+                            .frame(width: 32, height: 32)
+                    }
+            }
+        }
+        .task(id: videoURL) {
+            await loadOrGenerateThumbnail()
+        }
+    }
+
+    private func loadOrGenerateThumbnail() async {
+        let cache = ImageCache.default
+        let key = videoURL.absoluteString
+
+        // 캐시에서 이미지 가져오기
+        if let result = try? await cache.retrieveImage(forKey: key),
+           let uiImage = result.image {
+            await MainActor.run {
+                thumbnailImage = Image(uiImage: uiImage)
+                isLoading = false
+            }
+            return
+        }
+
+        // 썸네일 생성
+        let headers = [
+            "SeSACKey": apiKey,
+            "Authorization": accessToken ?? ""
+        ]
+        let asset = AVURLAsset(
+            url: videoURL,
+            options: ["AVURLAssetHTTPHeaderFieldsKey": headers]
+        )
+        // 플레이 가능 여부 확인
+        guard (try? await asset.load(.isPlayable)) != nil else {
+            await MainActor.run { isLoading = false }
+            return
+        }
+
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        let scale = UIScreen.main.scale
+        generator.maximumSize = CGSize(
+            width: targetSize.width * scale,
+            height: targetSize.height * scale
+        )
+        let time = CMTime(seconds: 1, preferredTimescale: 600)
+        
+        // 만료 정책
+        let infos: KingfisherOptionsInfo = [
+            .memoryCacheExpiration(.days(1)),
+            .diskCacheExpiration(.days(7))
+        ]
+        
+        let parsed = KingfisherParsedOptionsInfo(infos)
+
+        do {
+            let cgImage = try generator.copyCGImage(at: time, actualTime: nil)
+            let uiImage = UIImage(cgImage: cgImage)
+            // 캐시에 저장 (memory+disk)
+            try await cache.store(uiImage, forKey: key, options: parsed)
+            await MainActor.run {
+                thumbnailImage = Image(uiImage: uiImage)
+                isLoading = false
+            }
+        }
+        catch {
+            await MainActor.run { isLoading = false }
+            print("❌ Thumbnail generation failed:", error)
+        }
+    }
+}

--- a/FLOV/Domain/Constant/CachePolicy.swift
+++ b/FLOV/Domain/Constant/CachePolicy.swift
@@ -1,0 +1,14 @@
+//
+//  CachePolicy.swift
+//  FLOV
+//
+//  Created by 조우현 on 5/30/25.
+//
+
+import Foundation
+
+enum CachePolicy {
+    case memoryOnly
+    case diskOnly
+    case memoryAndDiskWithOriginal
+}

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -120,7 +120,7 @@ private extension ActivityView {
     }
     
     func newActivityCard(activity: ActivitySummaryEntity) -> some View {
-        KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 1)
+        KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 1, cachePolicy: .memoryOnly)
             .clipShape(RoundedRectangle(cornerRadius: 20))
             .overlay {
                 VStack(alignment: .leading, spacing: 12) {

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -120,7 +120,8 @@ private extension ActivityView {
     }
     
     func newActivityCard(activity: ActivitySummaryEntity) -> some View {
-        RoundedRectangle(cornerRadius: 20)
+        KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 1)
+            .clipShape(RoundedRectangle(cornerRadius: 20))
             .overlay {
                 VStack(alignment: .leading, spacing: 12) {
                     HStack {
@@ -150,6 +151,7 @@ private extension ActivityView {
                         .foregroundStyle(.gray30)
                         .lineLimit(3)
                 }
+                .shadow(radius: 2)
                 .padding()
             }
     }

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ActivityView: View {
     @EnvironmentObject var pathModel: PathModel
     @StateObject var viewModel: ActivityViewModel
-
+    
     var body: some View {
         ScrollView(showsIndicators: false) {
             VStack {
@@ -81,12 +81,12 @@ private extension ActivityView {
         let cardHeight: CGFloat = 300
         let spacing: CGFloat = -30 // 카드 사이 간격
         let minScale: CGFloat = 0.7 // 옆 카드 최소 스케일
-
+        
         return GeometryReader { geo in
             let screenWidth = geo.size.width
             let cardWidth = screenWidth * cardWidthRatio
             let sidePadding = (screenWidth - cardWidth) / 2
-
+            
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: spacing) {
                     ForEach(viewModel.output.newActivities, id: \.id) { activity in
@@ -120,40 +120,45 @@ private extension ActivityView {
     }
     
     func newActivityCard(activity: ActivitySummaryEntity) -> some View {
-        KFRemoteImageView(path: activity.thumbnailURLs[0], aspectRatio: 1, cachePolicy: .memoryOnly)
-            .clipShape(RoundedRectangle(cornerRadius: 20))
-            .overlay {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        LocationTag(location: activity.country)
-                        Spacer()
-                    }
-                    
+        return KFRemoteImageView(
+            path: activity.thumbnailURLs[0],
+            aspectRatio: 1,
+            cachePolicy: .memoryOnly,
+            height: 300
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+        .overlay {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    LocationTag(location: activity.country)
                     Spacer()
-                    
-                    Text(activity.title)
-                        .font(.Body.body0)
-                        .foregroundStyle(.white)
-                        .lineLimit(1)
-                    
-                    HStack(spacing: 2) {
-                        Image(.icnWonWhite)
-                            .resizable()
-                            .frame(width: 16, height: 16)
-                        
-                        Text("\(activity.finalPrice)원")
-                            .font(.Caption.caption0)
-                            .foregroundStyle(.white)
-                    }
-                    
-                    Text(viewModel.output.activityDetails[activity.id]?.description ?? "...")
-                        .font(.Caption.caption1)
-                        .foregroundStyle(.gray30)
-                        .lineLimit(3)
                 }
-                .shadow(radius: 2)
-                .padding()
+                
+                Spacer()
+                
+                Text(activity.title)
+                    .font(.Body.body0)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                
+                HStack(spacing: 2) {
+                    Image(.icnWonWhite)
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                    
+                    Text("\(activity.finalPrice)원")
+                        .font(.Caption.caption0)
+                        .foregroundStyle(.white)
+                }
+                
+                Text(viewModel.output.activityDetails[activity.id]?.description ?? "...")
+                    .font(.Caption.caption1)
+                    .foregroundStyle(.gray30)
+                    .lineLimit(3)
             }
+            .shadow(radius: 2)
+            .padding()
+        }
     }
 }
 

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -39,7 +39,6 @@ struct ActivityView: View {
         .onAppear {
             viewModel.action(.fetchNewActivities)
             viewModel.action(.fetchRecommendedActivities)
-            viewModel.action(.fetchAllActivities)
         }
     }
 }
@@ -181,7 +180,6 @@ private extension ActivityView {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: 20) {
                 ForEach(viewModel.output.recommendedActivities, id: \.id) { activity in
-                    // TODO: 전체 ActivityCard와 상태 공유 X
                     ActivityCard(isRecommended: true, activity: activity, description: viewModel.output.activityDetails[activity.id]?.description) { isKeep in
                         viewModel.action(.keepToggle(id: activity.id, keepStatus: isKeep))
                     }

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -109,7 +109,7 @@ private extension ActivityView {
                         }
                         .frame(width: cardWidth, height: cardHeight)
                         .onAppear {
-                             viewModel.action(.fetchActivityDetail(id: activity.id))
+                            viewModel.action(.fetchActivityDetail(id: activity.id))
                         }
                     }
                 }
@@ -180,12 +180,18 @@ private extension ActivityView {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: 20) {
                 ForEach(viewModel.output.recommendedActivities, id: \.id) { activity in
-                    ActivityCard(isRecommended: true, activity: activity, description: viewModel.output.activityDetails[activity.id]?.description) { isKeep in
+                    let description = viewModel.output.activityDetails[activity.id]?.description
+                    
+                    ActivityCard(
+                        isRecommended: true,
+                        activity: activity,
+                        description: description
+                    ) { isKeep in
                         viewModel.action(.keepToggle(id: activity.id, keepStatus: isKeep))
                     }
-                        .onAppear {
-                            viewModel.action(.fetchActivityDetail(id: activity.id))
-                        }
+                    .onAppear {
+                        viewModel.action(.fetchActivityDetail(id: activity.id))
+                    }
                 }
             }
             .padding()
@@ -297,9 +303,19 @@ private extension ActivityView {
                 ) { isKeep in
                     viewModel.action(.keepToggle(id: activity.id, keepStatus: isKeep))
                 }
-                    .onAppear {
-                        viewModel.action(.fetchActivityDetail(id: activity.id))
+                .onAppear {
+                    viewModel.action(.fetchActivityDetail(id: activity.id))
+                    
+                    if activity.id == viewModel.output.allActivities.last?.id,
+                       viewModel.output.nextCursor != nil {
+                        viewModel.action(.fetchMoreActivities)
                     }
+                }
+            }
+            
+            if viewModel.output.isLodingMore {
+                ProgressView()
+                    .padding()
             }
         }
         .padding()

--- a/FLOV/Feature/02_Activity/View/ActivityView.swift
+++ b/FLOV/Feature/02_Activity/View/ActivityView.swift
@@ -120,7 +120,7 @@ private extension ActivityView {
     }
     
     func newActivityCard(activity: ActivitySummaryEntity) -> some View {
-        return KFRemoteImageView(
+        KFRemoteImageView(
             path: activity.thumbnailURLs[0],
             aspectRatio: 1,
             cachePolicy: .memoryOnly,


### PR DESCRIPTION
close #28 

## *⛳️ Work Description*
- 추천액티비티와 전체 액티비티에 중복이 발생하지 않도록 수정했습니다.
- AllActivityView에 페이지네이션 기능을 구현했습니다.
- KFImage를 통해 이미지로더를 구현했습니다.
- 이미지 캐싱 정책을 추가했습니다.
- 썸네일 확장자가 mp4일 경우 동영상의 썸네일을 보여주는식으로 처리했습니다.

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|New 및 추천|<img width="250" alt="AppFlow" src="https://github.com/user-attachments/assets/c83e4992-bc00-4d48-98c5-474e6886ca37">|
|전체 및 필터|<img width="250" alt="AppFlow" src="https://github.com/user-attachments/assets/9fdb6466-496e-4d0d-96ba-8ba626c55773">|

## *❓ 고민한 지점*
- 하나의 뷰에 동일한 액티비티 데이터가 있을 경우 좋아요 상태가 동기화 되지 않는 문제가 있었습니다.
  - 추천액티비티에 있는 액티비티는 전체 액티비티에 보이지 않도록 하면서 사용상 불편함을 제거했습니다.
- 캐시정책은 조금 더 세밀하게 조정해야 합니다.
  - 현재는 New의 이미지는 메모리에, 추천과 전체 액티비티는 디스크에 저장하도록 설정했습니다.
  - 추후 ActivityCard가 다른 뷰에서 재사용될 경우 캐싱 정책 수정을 고려해야 합니다 -> 디스크에 너무 많은 데이터가 저장되는 것을 막기 위함
  - Etag관련한 기능도 구현해야 합니다.
- 동영상 재생 버튼은 구현하지 않았습니다.
  - 추후 이 버튼을 탭했을 때 재생 로직을 구현해야 합니다.


## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
